### PR TITLE
Refactor: Implement Clean Separation of Concerns in Show Command

### DIFF
--- a/cmd/treex/cmd/show.go
+++ b/cmd/treex/cmd/show.go
@@ -2,11 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/adebert/treex/pkg/info"
-	"github.com/adebert/treex/pkg/tree"
-	"github.com/adebert/treex/pkg/tui"
+	"github.com/adebert/treex/pkg/app"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +49,7 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create configuration from flags
-	config := &tree.DisplayConfig{
+	options := app.RenderOptions{
 		Verbose:    verbose,
 		NoColor:    noColor,
 		Minimal:    minimal,
@@ -61,116 +58,15 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 		SafeMode:   safeMode,
 	}
 
-	// Delegate to business logic  
-	if err := displayAnnotatedTree(targetPath, config, os.Stdout); err != nil {
+	// Call the main business logic
+	result, err := app.RenderAnnotatedTree(targetPath, options)
+	if err != nil {
 		return fmt.Errorf("failed to display tree: %w", err)
 	}
 
+	// Output the result
+	fmt.Print(result.Output)
 	return nil
 }
 
-// displayAnnotatedTree handles the complete business logic for displaying an annotated tree
-func displayAnnotatedTree(targetPath string, config *tree.DisplayConfig, output *os.File) error {
-	if config.Verbose {
-		fmt.Fprintf(output, "Analyzing directory: %s\n", targetPath)
-		fmt.Fprintln(output, "Verbose mode enabled - will show parsed .info structure")
-		fmt.Fprintln(output)
-	}
-
-	// Phase 1 - Parse .info files (nested)
-	annotations, err := info.ParseDirectoryTree(targetPath)
-	if err != nil {
-		return fmt.Errorf("failed to parse .info files: %w", err)
-	}
-
-	if config.Verbose {
-		fmt.Fprintln(output, "=== Parsed Annotations ===")
-		if len(annotations) == 0 {
-			fmt.Fprintln(output, "No annotations found (no .info file or empty file)")
-		} else {
-			for path, annotation := range annotations {
-				fmt.Fprintf(output, "Path: %s\n", path)
-				if annotation.Title != "" {
-					fmt.Fprintf(output, "  Title: %s\n", annotation.Title)
-				}
-				fmt.Fprintf(output, "  Description: %s\n", annotation.Description)
-				fmt.Fprintln(output)
-			}
-		}
-		fmt.Fprintln(output, "=== End Annotations ===")
-		fmt.Fprintln(output)
-	}
-
-	// Phase 2 - Build file tree (using nested annotations with filtering options)
-	var root *tree.Node
-	if config.IgnoreFile != "" || config.MaxDepth != -1 {
-		// Build tree with filtering options
-		root, err = tree.BuildTreeNestedWithOptions(targetPath, config.IgnoreFile, config.MaxDepth)
-		if err != nil {
-			return fmt.Errorf("failed to build file tree with options: %w", err)
-		}
-	} else {
-		// Build tree without filtering
-		root, err = tree.BuildTreeNested(targetPath)
-		if err != nil {
-			return fmt.Errorf("failed to build file tree: %w", err)
-		}
-	}
-
-	if config.Verbose {
-		fmt.Fprintln(output, "=== File Tree Structure ===")
-		err = tree.WalkTree(root, func(node *tree.Node, depth int) error {
-			indent := ""
-			for i := 0; i < depth; i++ {
-				indent += "  "
-			}
-			
-			nodeType := "file"
-			if node.IsDir {
-				nodeType = "dir"
-			}
-			
-			annotationInfo := ""
-			if node.Annotation != nil {
-				if node.Annotation.Title != "" {
-					annotationInfo = fmt.Sprintf(" [%s]", node.Annotation.Title)
-				} else {
-					annotationInfo = " [annotated]"
-				}
-			}
-			
-			fmt.Fprintf(output, "%s%s (%s)%s\n", indent, node.Name, nodeType, annotationInfo)
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("failed to walk tree: %w", err)
-		}
-		fmt.Fprintln(output, "=== End Tree Structure ===")
-		fmt.Fprintln(output)
-	}
-
-	// Phase 3 - Render tree with beautiful styling
-	if config.Verbose {
-		fmt.Fprintf(output, "treex analysis of: %s\n", targetPath)
-		fmt.Fprintf(output, "Found %d annotations\n", len(annotations))
-		fmt.Fprintln(output)
-	}
-	
-	// Choose the appropriate renderer based on flags
-	if config.NoColor {
-		// Use plain renderer without colors
-		err = tui.RenderPlainTree(output, root, true)
-	} else if config.Minimal {
-		// Use minimal styling
-		err = tui.RenderMinimalStyledTreeWithSafeMode(output, root, true, config.SafeMode)
-	} else {
-		// Use full beautiful styling
-		err = tui.RenderStyledTreeWithSafeMode(output, root, true, config.SafeMode)
-	}
-	
-	if err != nil {
-		return fmt.Errorf("failed to render tree: %w", err)
-	}
-	
-	return nil
-} 
+ 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,0 +1,153 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/adebert/treex/pkg/info"
+	"github.com/adebert/treex/pkg/tree"
+	"github.com/adebert/treex/pkg/tui"
+)
+
+// RenderOptions contains configuration options for rendering annotated trees
+type RenderOptions struct {
+	Verbose    bool
+	NoColor    bool
+	Minimal    bool
+	IgnoreFile string
+	MaxDepth   int
+	SafeMode   bool
+}
+
+// RenderResult contains the rendered output and optional verbose information
+type RenderResult struct {
+	Output string
+	Stats  *RenderStats
+}
+
+// RenderStats contains statistics about the rendering process
+type RenderStats struct {
+	AnnotationsFound int
+	TreeGenerated    bool
+}
+
+// RenderAnnotatedTree is the main business logic function that generates an annotated tree
+// This function handles all the core application logic and returns a complete rendered string
+func RenderAnnotatedTree(targetPath string, options RenderOptions) (*RenderResult, error) {
+	var outputBuilder strings.Builder
+	stats := &RenderStats{}
+
+	if options.Verbose {
+		fmt.Fprintf(&outputBuilder, "Analyzing directory: %s\n", targetPath)
+		fmt.Fprintln(&outputBuilder, "Verbose mode enabled - will show parsed .info structure")
+		fmt.Fprintln(&outputBuilder)
+	}
+
+	// Phase 1 - Parse .info files (nested)
+	annotations, err := info.ParseDirectoryTree(targetPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse .info files: %w", err)
+	}
+
+	stats.AnnotationsFound = len(annotations)
+
+	if options.Verbose {
+		fmt.Fprintln(&outputBuilder, "=== Parsed Annotations ===")
+		if len(annotations) == 0 {
+			fmt.Fprintln(&outputBuilder, "No annotations found (no .info file or empty file)")
+		} else {
+			for path, annotation := range annotations {
+				fmt.Fprintf(&outputBuilder, "Path: %s\n", path)
+				if annotation.Title != "" {
+					fmt.Fprintf(&outputBuilder, "  Title: %s\n", annotation.Title)
+				}
+				fmt.Fprintf(&outputBuilder, "  Description: %s\n", annotation.Description)
+				fmt.Fprintln(&outputBuilder)
+			}
+		}
+		fmt.Fprintln(&outputBuilder, "=== End Annotations ===")
+		fmt.Fprintln(&outputBuilder)
+	}
+
+	// Phase 2 - Build file tree (using nested annotations with filtering options)
+	var root *tree.Node
+	if options.IgnoreFile != "" || options.MaxDepth != -1 {
+		// Build tree with filtering options
+		root, err = tree.BuildTreeNestedWithOptions(targetPath, options.IgnoreFile, options.MaxDepth)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build file tree with options: %w", err)
+		}
+	} else {
+		// Build tree without filtering
+		root, err = tree.BuildTreeNested(targetPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build file tree: %w", err)
+		}
+	}
+
+	stats.TreeGenerated = true
+
+	if options.Verbose {
+		fmt.Fprintln(&outputBuilder, "=== File Tree Structure ===")
+		err = tree.WalkTree(root, func(node *tree.Node, depth int) error {
+			indent := ""
+			for i := 0; i < depth; i++ {
+				indent += "  "
+			}
+			
+			nodeType := "file"
+			if node.IsDir {
+				nodeType = "dir"
+			}
+			
+			annotationInfo := ""
+			if node.Annotation != nil {
+				if node.Annotation.Title != "" {
+					annotationInfo = fmt.Sprintf(" [%s]", node.Annotation.Title)
+				} else {
+					annotationInfo = " [annotated]"
+				}
+			}
+			
+			fmt.Fprintf(&outputBuilder, "%s%s (%s)%s\n", indent, node.Name, nodeType, annotationInfo)
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to walk tree: %w", err)
+		}
+		fmt.Fprintln(&outputBuilder, "=== End Tree Structure ===")
+		fmt.Fprintln(&outputBuilder)
+	}
+
+	// Phase 3 - Render tree with beautiful styling
+	if options.Verbose {
+		fmt.Fprintf(&outputBuilder, "treex analysis of: %s\n", targetPath)
+		fmt.Fprintf(&outputBuilder, "Found %d annotations\n", len(annotations))
+		fmt.Fprintln(&outputBuilder)
+	}
+	
+	// Choose the appropriate renderer based on options and render to string
+	var renderedTree string
+	if options.NoColor {
+		// Use plain renderer without colors
+		renderedTree, err = tui.RenderPlainTreeToString(root, true)
+	} else if options.Minimal {
+		// Use minimal styling
+		renderedTree, err = tui.RenderMinimalStyledTreeToString(root, true, options.SafeMode)
+	} else {
+		// Use full beautiful styling
+		renderedTree, err = tui.RenderStyledTreeToStringWithSafeMode(root, true, options.SafeMode)
+	}
+	
+	if err != nil {
+		return nil, fmt.Errorf("failed to render tree: %w", err)
+	}
+	
+	// Append the rendered tree to our output
+	outputBuilder.WriteString(renderedTree)
+	
+	return &RenderResult{
+		Output: outputBuilder.String(),
+		Stats:  stats,
+	}, nil
+} 

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRenderAnnotatedTree_BasicFunctionality(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	
+	// Create a simple .info file
+	infoContent := `cmd/
+Main binary command with subcommands for different operations.
+
+src/
+Source code with core business logic.
+`
+	
+	infoPath := tempDir + "/.info"
+	if err := os.WriteFile(infoPath, []byte(infoContent), 0644); err != nil {
+		t.Fatalf("Failed to create test .info file: %v", err)
+	}
+	
+	// Create some test directories
+	if err := os.MkdirAll(tempDir+"/cmd", 0755); err != nil {
+		t.Fatalf("Failed to create cmd directory: %v", err)
+	}
+	if err := os.MkdirAll(tempDir+"/src", 0755); err != nil {
+		t.Fatalf("Failed to create src directory: %v", err)
+	}
+	
+	// Test basic rendering
+	options := RenderOptions{
+		Verbose:    false,
+		NoColor:    true, // Use plain text for predictable testing
+		Minimal:    false,
+		IgnoreFile: "",
+		MaxDepth:   -1,
+		SafeMode:   true,
+	}
+	
+	result, err := RenderAnnotatedTree(tempDir, options)
+	if err != nil {
+		t.Fatalf("RenderAnnotatedTree failed: %v", err)
+	}
+	
+	// Verify the result
+	if result == nil {
+		t.Fatal("Expected non-nil result")
+	}
+	
+	if result.Stats == nil {
+		t.Fatal("Expected non-nil stats")
+	}
+	
+	if result.Stats.AnnotationsFound != 2 {
+		t.Errorf("Expected 2 annotations, got %d", result.Stats.AnnotationsFound)
+	}
+	
+	if !result.Stats.TreeGenerated {
+		t.Error("Expected tree to be generated")
+	}
+	
+	// Check that output contains expected content
+	output := result.Output
+	if !strings.Contains(output, "cmd") {
+		t.Error("Expected output to contain 'cmd'")
+	}
+	
+	if !strings.Contains(output, "src") {
+		t.Error("Expected output to contain 'src'")
+	}
+	
+	// Check that annotations are included
+	if !strings.Contains(output, "Main binary command") {
+		t.Error("Expected output to contain cmd annotation")
+	}
+	
+	if !strings.Contains(output, "Source code with core") {
+		t.Error("Expected output to contain src annotation")
+	}
+}
+
+func TestRenderAnnotatedTree_VerboseMode(t *testing.T) {
+	// Use a simple directory without .info files
+	tempDir := t.TempDir()
+	
+	options := RenderOptions{
+		Verbose:    true,
+		NoColor:    true,
+		Minimal:    false,
+		IgnoreFile: "",
+		MaxDepth:   -1,
+		SafeMode:   true,
+	}
+	
+	result, err := RenderAnnotatedTree(tempDir, options)
+	if err != nil {
+		t.Fatalf("RenderAnnotatedTree failed: %v", err)
+	}
+	
+	// In verbose mode, output should contain analysis information
+	output := result.Output
+	if !strings.Contains(output, "Analyzing directory:") {
+		t.Error("Expected verbose output to contain 'Analyzing directory:'")
+	}
+	
+	if !strings.Contains(output, "=== Parsed Annotations ===") {
+		t.Error("Expected verbose output to contain annotations section")
+	}
+	
+	if !strings.Contains(output, "Found 0 annotations") {
+		t.Error("Expected verbose output to show annotation count")
+	}
+}
+
+func TestRenderAnnotatedTree_InvalidPath(t *testing.T) {
+	options := RenderOptions{
+		Verbose:    false,
+		NoColor:    true,
+		Minimal:    false,
+		IgnoreFile: "",
+		MaxDepth:   -1,
+		SafeMode:   true,
+	}
+	
+	// Test with non-existent path
+	_, err := RenderAnnotatedTree("/nonexistent/path/12345", options)
+	if err == nil {
+		t.Error("Expected error for non-existent path")
+	}
+} 

--- a/pkg/tui/styled_renderer.go
+++ b/pkg/tui/styled_renderer.go
@@ -383,6 +383,21 @@ func RenderStyledTreeToString(root *tree.Node, showAnnotations bool) (string, er
 	return builder.String(), nil
 }
 
+// RenderStyledTreeToStringWithSafeMode renders a styled tree to a string with explicit safe mode control
+func RenderStyledTreeToStringWithSafeMode(root *tree.Node, showAnnotations bool, safeMode bool) (string, error) {
+	var builder strings.Builder
+	renderer := NewStyledTreeRenderer(&builder, showAnnotations)
+	if safeMode {
+		renderer = renderer.WithSafeMode(true)
+	}
+	
+	if err := renderer.Render(root); err != nil {
+		return "", err
+	}
+	
+	return builder.String(), nil
+}
+
 // RenderStyledTreeWithSafeMode renders a tree with beautiful styling and explicit safe mode control
 func RenderStyledTreeWithSafeMode(writer io.Writer, root *tree.Node, showAnnotations bool, safeMode bool) error {
 	renderer := NewStyledTreeRenderer(writer, showAnnotations)
@@ -414,4 +429,33 @@ func RenderPlainTree(writer io.Writer, root *tree.Node, showAnnotations bool) er
 	renderer := NewStyledTreeRenderer(writer, showAnnotations).
 		WithStyles(NewNoColorTreeStyles())
 	return renderer.Render(root)
+}
+
+// RenderPlainTreeToString renders a tree without colors to a string
+func RenderPlainTreeToString(root *tree.Node, showAnnotations bool) (string, error) {
+	var builder strings.Builder
+	renderer := NewStyledTreeRenderer(&builder, showAnnotations).
+		WithStyles(NewNoColorTreeStyles())
+	
+	if err := renderer.Render(root); err != nil {
+		return "", err
+	}
+	
+	return builder.String(), nil
+}
+
+// RenderMinimalStyledTreeToString renders a tree with minimal styling to a string
+func RenderMinimalStyledTreeToString(root *tree.Node, showAnnotations bool, safeMode bool) (string, error) {
+	var builder strings.Builder
+	renderer := NewStyledTreeRenderer(&builder, showAnnotations).
+		WithStyles(NewMinimalTreeStyles())
+	if safeMode {
+		renderer = renderer.WithSafeMode(true)
+	}
+	
+	if err := renderer.Render(root); err != nil {
+		return "", err
+	}
+	
+	return builder.String(), nil
 } 


### PR DESCRIPTION
Major architectural refactoring to establish proper separation of concerns.

## Changes
- NEW: pkg/app package with main business logic  
- REFACTOR: cmd/show.go to thin CLI layer (100+ lines -> 25 lines)
- ENHANCE: pkg/tui with ToString functions for better testability

## Benefits
- Clean separation between CLI and business logic
- Business logic is now unit testable  
- Core functionality can be reused by other interfaces
- All existing functionality preserved
- All tests passing

## Architecture 
Before: CLI -> Direct pkg calls -> Output
After: CLI -> app.RenderAnnotatedTree() -> String output

This establishes a solid foundation following clean architecture principles.