### PR TITLE
Rename commands: add-info to add, gen-info to import

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ treex --help # for more
 # adding annotations
 treex init # defaults to --depth of 3 not to create a monster, can be overwrittern
 treex add <path> <info> # adds info to the ,info
-trexx import <path>  # if you have a hand-generated text like this
+treex import <path>  # if you have a hand-generated text like this
 ```
 
 ### Working with .info Files
@@ -124,13 +124,13 @@ This command will:
 - Add or update the entry for the specified path
 - Prompt you if an entry already exists (replace, append, or skip)
 
-#### 3. Bulk Generation with `gen-info`
+#### 3. Bulk Generation with `import`
 
 Generate multiple `.info` files from a hand-written annotated tree structure:
 
 ```bash
 # Generate .info files from an annotated tree structure
-treex gen-info my-tree-structure.txt
+treex import my-tree-structure.txt
 ```
 
 This command takes a tree-like input file (like those commonly found in project documentation) and automatically creates `.info` files in the appropriate directories.

--- a/cmd/treex/cmd/gen_info.go
+++ b/cmd/treex/cmd/gen_info.go
@@ -7,8 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var genInfoCmd = &cobra.Command{
-	Use:   "gen-info <file>",
+var importCmd = &cobra.Command{
+	Use:   "import <file>",
 	Short: "Generate .info files from annotated tree structure",
 	Long: `Generate .info files from a hand-written annotated tree structure.
 
@@ -32,16 +32,16 @@ Or with traditional tree connectors:
 Both formats work equally well. This will generate appropriate .info files 
 in the corresponding directories.`,
 	Args: cobra.ExactArgs(1),
-	RunE: runGenInfoCmd,
+	RunE: runImportCmd,
 }
 
 func init() {
 	// Register the command with root
-	rootCmd.AddCommand(genInfoCmd)
+	rootCmd.AddCommand(importCmd)
 }
 
-// runGenInfoCmd handles the CLI interface for gen-info command
-func runGenInfoCmd(cmd *cobra.Command, args []string) error {
+// runImportCmd handles the CLI interface for import command
+func runImportCmd(cmd *cobra.Command, args []string) error {
 	inputFile := args[0]
 	
 	// Delegate to business logic

--- a/cmd/treex/cmd/info_files.go
+++ b/cmd/treex/cmd/info_files.go
@@ -56,7 +56,7 @@ func showInfoFilesHelp() {
 	fmt.Println("   • treex automatically merges all .info files")
 	fmt.Println()
 	fmt.Println("⚡ Auto-Generation:")
-	fmt.Println("   Use 'treex gen-info <tree-file>' to generate .info files")
+	fmt.Println("   Use 'treex import <tree-file>' to generate .info files")
 	fmt.Println("   from a simple annotated tree structure.")
 	fmt.Println()
 	fmt.Println("   Example input:")

--- a/cmd/treex/cmd/root.go
+++ b/cmd/treex/cmd/root.go
@@ -62,7 +62,7 @@ Each .info file can only describe paths within its own directory for security.
 
 GENERATING .INFO FILES:
 
-Use 'treex gen-info <file>' to generate .info files from annotated tree structures.
+Use 'treex import <file>' to generate .info files from annotated tree structures.
 The input can be simple:
     myproject/cmd The CLI utilities
     myproject/docs Documentation

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -4,7 +4,7 @@
 
 ```bash
 treex [path] [flags]
-treex gen-info <file>
+treex import <file>
 ```
 
 ## Arguments
@@ -216,7 +216,7 @@ Supports standard .gitignore syntax:
 
 ## Commands
 
-### `treex gen-info <file>`
+### `treex import <file>`
 
 Generate `.info` files from a hand-written annotated tree structure.
 
@@ -225,7 +225,7 @@ Generate `.info` files from a hand-written annotated tree structure.
 - `<file>`: Input file containing tree-like structure with paths and descriptions
 
 **Description:**
-The `gen-info` command parses a text file containing a tree-like representation of your project structure and automatically generates appropriate `.info` files in the correct directories.
+The `import` command parses a text file containing a tree-like representation of your project structure and automatically generates appropriate `.info` files in the correct directories.
 
 **Input Format:**
 
@@ -247,7 +247,7 @@ project-name
 **Example:**
 
 ```bash
-treex gen-info project-structure.txt
+treex import project-structure.txt
 ```
 
 **Error Handling:**


### PR DESCRIPTION
This PR renames two core commands as requested:

## Changes Made

### 1.1 Rename add-info → add
- Updated command definition from 'add-info' to 'add' 
- Updated all usage examples and help text
- Updated README.md documentation
- Commit: 62500e1

### 1.2 Rename gen-info → import  
- Updated command definition from 'gen-info' to 'import'
- Updated variable names for consistency (genInfoCmd → importCmd)
- Updated all documentation (README.md, OPTIONS.md)
- Updated references in root.go and info_files.go
- Commit: b289832

## Breaking Changes
⚠️ **No backwards compatibility** - old command names are completely removed as requested.

## Testing
- All existing tests pass
- Pre-commit hooks pass (linting, tests)
- Commands work with new names:
  - treex add [path] [description]
  - treex import [file]