### PR TITLE
Refactor: Separate CLI and App logic for verbose output, improve outp…

### DIFF
--- a/cmd/treex/cmd/show.go
+++ b/cmd/treex/cmd/show.go
@@ -114,9 +114,52 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to display tree: %w", err)
 	}
 
-	// Output the result
-	fmt.Print(result.Output)
+	// Output the result (conditionally handling verbose output)
+	if options.Verbose && result.VerboseOutput != nil {
+		printVerboseOutput(cmd, result.VerboseOutput)
+	}
+	// Use cmd.Print or fmt.Fprint(cmd.OutOrStdout(), ...) to respect output redirection
+	_, err = cmd.OutOrStdout().Write([]byte(result.Output))
+	if err != nil {
+		// If we can't write to output, return an error
+		return fmt.Errorf("failed to write output: %w", err)
+	}
+
 	return nil
+}
+
+// printVerboseOutput formats and prints the structured verbose information
+func printVerboseOutput(cmd *cobra.Command, verboseData *app.VerboseOutput) {
+	fmt.Fprintf(cmd.OutOrStdout(), "Analyzing directory: %s\n", verboseData.AnalyzedPath)
+	fmt.Fprintln(cmd.OutOrStdout(), "Verbose mode enabled - will show parsed .info structure")
+	fmt.Fprintln(cmd.OutOrStdout())
+
+	fmt.Fprintln(cmd.OutOrStdout(), "=== Parsed Annotations ===")
+	if len(verboseData.ParsedAnnotations) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No annotations found (no .info file or empty file)")
+	} else {
+		for path, annotation := range verboseData.ParsedAnnotations {
+			fmt.Fprintf(cmd.OutOrStdout(), "Path: %s\n", path)
+			if annotation.Title != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "  Title: %s\n", annotation.Title)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "  Description: %s\n", annotation.Description)
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "=== End Annotations ===")
+	fmt.Fprintln(cmd.OutOrStdout())
+
+	if verboseData.TreeStructure != "" {
+		fmt.Fprintln(cmd.OutOrStdout(), "=== File Tree Structure ===")
+		fmt.Fprint(cmd.OutOrStdout(), verboseData.TreeStructure)
+		fmt.Fprintln(cmd.OutOrStdout(), "=== End Tree Structure ===")
+		fmt.Fprintln(cmd.OutOrStdout())
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "treex analysis of: %s\n", verboseData.AnalyzedPath)
+	fmt.Fprintf(cmd.OutOrStdout(), "Found %d annotations\n", verboseData.FoundAnnotations)
+	fmt.Fprintln(cmd.OutOrStdout())
 }
 
 // getFormatListCmd creates a hidden command to list available formats

--- a/cmd/treex/cmd/show_test.go
+++ b/cmd/treex/cmd/show_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag" // Import pflag
+)
+
+// executeCommand is a helper function to execute a cobra command and capture its output.
+func executeCommand(root *cobra.Command, args ...string) (output string, err error) {
+	_, output, err = executeCommandC(root, args...)
+	return output, err
+}
+
+// executeCommandC is a helper function to execute a cobra command and capture its output and error streams.
+func executeCommandC(root *cobra.Command, args ...string) (c *cobra.Command, output string, err error) {
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs(args)
+
+	c, err = root.ExecuteC()
+
+	return c, buf.String(), err
+}
+
+func TestShowCmd_VerboseOutput(t *testing.T) {
+	tempDir := t.TempDir()
+	// .info content according to original parser rules:
+	// First line is title if followed by more description lines.
+	// Blank lines separate entries.
+	infoContent := "dummy.txt\nActual Title Line1\nActual Description Line2"
+	err := ioutil.WriteFile(filepath.Join(tempDir, ".info"), []byte(infoContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write .info file: %v", err)
+	}
+	_, err = os.Create(filepath.Join(tempDir, "dummy.txt"))
+	if err != nil {
+		t.Fatalf("Failed to create dummy.txt: %v", err)
+	}
+
+	// Reset global flags for a clean test environment for showCmd
+	// This is important because cobra flags can persist across test runs.
+	resetShowCmdFlags()
+
+
+	// Execute the show command with verbose flag
+	// Note: We are testing the `showCmd` directly.
+	// If `rootCmd` has persistent flags that `showCmd` relies on,
+	// they might need to be set up here or `rootCmd` should be executed.
+	// For this test, we assume `showCmd` can be tested in isolation or `rootCmd` is simple.
+	// To be absolutely sure, one might need to reinitialize rootCmd or use rootCmd.ExecuteC()
+
+	// Re-initialize root command and add show command to it for each test run
+	// to ensure flag states are clean.
+	testRootCmd := &cobra.Command{Use: "treex"}
+	testRootCmd.AddCommand(showCmd) // Add the actual showCmd
+
+	output, err := executeCommand(testRootCmd, "show", tempDir, "-v", "--format=no-color")
+	if err != nil {
+		t.Fatalf("ExecuteC failed: %v", err)
+	}
+
+	// Check for verbose output strings
+	expectedVerboseStrings := []string{
+		"Analyzing directory:",
+		"Verbose mode enabled",
+		"=== Parsed Annotations ===",
+		"Path: dummy.txt",
+		"  Title: Actual Title Line1",
+		"  Description: Actual Title Line1\nActual Description Line2", // Full description includes title line
+		"=== End Annotations ===",
+		"=== File Tree Structure ===",
+		"dummy.txt (file) [Actual Title Line1]",
+		"=== End Tree Structure ===",
+		"treex analysis of:",
+		"Found 1 annotations",
+	}
+
+	for _, s := range expectedVerboseStrings {
+		if !strings.Contains(output, s) {
+			t.Errorf("Expected output to contain verbose string: %q\nFull output:\n%s", s, output)
+		}
+	}
+
+	// Check that the main tree output is also present
+	if !strings.Contains(output, "dummy.txt") {
+		t.Errorf("Expected output to contain the tree item 'dummy.txt'.\nFull output:\n%s", output)
+	}
+
+	// The no-color renderer output for an item with a title.
+	// The exact spacing might vary, so check for presence of file and title.
+	if !strings.Contains(output, "dummy.txt") || !strings.Contains(output, "Actual Title Line1") {
+		 t.Errorf("Expected output to contain rendered 'dummy.txt' and 'Actual Title Line1'.\nFull output:\n%s", output)
+	}
+	// More precise check if needed: "dummy.txt                           Actual Title Line1"
+}
+
+// resetShowCmdFlags resets the flags for showCmd to their default values.
+// This is necessary because cobra commands reuse flag instances.
+func resetShowCmdFlags() {
+	verbose = false // Assuming verbose is the flag variable for -v
+	path = ""
+	outputFormat = "color" // Default value
+	noColor = false
+	minimal = false
+	ignoreFile = ".gitignore" // Default value
+	maxDepth = 10            // Default value
+	safeMode = false
+
+	// If flags are defined on showCmd directly, reset them:
+	// showCmd.Flags().VisitAll(func(f *pflag.Flag) {
+	// 	f.Value.Set(f.DefValue)
+	// })
+	// However, these are global vars in the current codebase.
+}
+
+func TestShowCmd_NonVerboseOutput(t *testing.T) {
+	tempDir := t.TempDir()
+	// Use a .info file with a clear title and description, no internal blank lines in the entry
+	infoContent := "file.txt\nMy File Title Line1\nMy File Description Line2"
+	err := ioutil.WriteFile(filepath.Join(tempDir, ".info"), []byte(infoContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write .info file: %v", err)
+	}
+	_, err = os.Create(filepath.Join(tempDir, "file.txt"))
+	if err != nil {
+		t.Fatalf("Failed to create file.txt: %v", err)
+	}
+
+	resetShowCmdFlags()
+	// Attempt to more thoroughly reset flag states on the shared showCmd object
+	showCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		f.Changed = false
+		// For flags that might not have a DefValue correctly set by default after parsing,
+		// or if their value isn't reset by just setting the bound variable,
+		// explicitly set them to their default string value.
+		// This is more of a diagnostic step.
+		// f.Value.Set(f.DefValue) // This can be problematic if DefValue isn't what we expect now
+	})
+
+	testRootCmd := &cobra.Command{Use: "treex"}
+	testRootCmd.AddCommand(showCmd) // ensure showCmd is part of this specific test's root
+
+	output, err := executeCommand(testRootCmd, "show", tempDir, "--format=no-color")
+	if err != nil {
+		t.Fatalf("ExecuteC failed: %v", err)
+	}
+
+	// Check that verbose output strings are NOT present
+	unexpectedVerboseStrings := []string{
+		"Analyzing directory:",
+		"Verbose mode enabled",
+		"=== Parsed Annotations ===",
+	}
+
+	for _, s := range unexpectedVerboseStrings {
+		if strings.Contains(output, s) {
+			t.Errorf("Expected output NOT to contain verbose string: %q\nFull output:\n%s", s, output)
+		}
+	}
+
+	// Check that the main tree output is present and shows the title
+	containsFile := strings.Contains(output, "file.txt")
+	containsTitle := strings.Contains(output, "My File Title Line1")
+
+	if !containsFile || !containsTitle {
+		t.Errorf("Output check failed. Contains 'file.txt': %t, Contains 'My File Title Line1': %t.\nFull output:\n---\n%s\n---", containsFile, containsTitle, output)
+	}
+	// A more precise check if the renderer's behavior is stable for no-color:
+	// e.g. if !strings.Contains(output, "file.txt                            My File Title Line1")
+}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -24,8 +24,17 @@ type RenderOptions struct {
 
 // RenderResult contains the rendered output and optional verbose information
 type RenderResult struct {
-	Output string
-	Stats  *RenderStats
+	Output        string
+	Stats         *RenderStats
+	VerboseOutput *VerboseOutput // New field for structured verbose info
+}
+
+// VerboseOutput holds structured information for verbose mode
+type VerboseOutput struct {
+	AnalyzedPath      string
+	ParsedAnnotations map[string]*info.Annotation // Changed to *info.Annotation
+	TreeStructure     string                      // Keep tree structure as string for now, could be structured further if needed
+	FoundAnnotations  int
 }
 
 // RenderStats contains statistics about the rendering process
@@ -37,13 +46,11 @@ type RenderStats struct {
 // RenderAnnotatedTree is the main business logic function that generates an annotated tree
 // This function handles all the core application logic and returns a complete rendered string
 func RenderAnnotatedTree(targetPath string, options RenderOptions) (*RenderResult, error) {
-	var outputBuilder strings.Builder
 	stats := &RenderStats{}
+	verboseOutput := &VerboseOutput{}
 
 	if options.Verbose {
-		fmt.Fprintf(&outputBuilder, "Analyzing directory: %s\n", targetPath)
-		fmt.Fprintln(&outputBuilder, "Verbose mode enabled - will show parsed .info structure")
-		fmt.Fprintln(&outputBuilder)
+		verboseOutput.AnalyzedPath = targetPath
 	}
 
 	// Phase 1 - Parse .info files (nested)
@@ -53,23 +60,9 @@ func RenderAnnotatedTree(targetPath string, options RenderOptions) (*RenderResul
 	}
 
 	stats.AnnotationsFound = len(annotations)
-
 	if options.Verbose {
-		fmt.Fprintln(&outputBuilder, "=== Parsed Annotations ===")
-		if len(annotations) == 0 {
-			fmt.Fprintln(&outputBuilder, "No annotations found (no .info file or empty file)")
-		} else {
-			for path, annotation := range annotations {
-				fmt.Fprintf(&outputBuilder, "Path: %s\n", path)
-				if annotation.Title != "" {
-					fmt.Fprintf(&outputBuilder, "  Title: %s\n", annotation.Title)
-				}
-				fmt.Fprintf(&outputBuilder, "  Description: %s\n", annotation.Description)
-				fmt.Fprintln(&outputBuilder)
-			}
-		}
-		fmt.Fprintln(&outputBuilder, "=== End Annotations ===")
-		fmt.Fprintln(&outputBuilder)
+		verboseOutput.ParsedAnnotations = annotations
+		verboseOutput.FoundAnnotations = len(annotations)
 	}
 
 	// Phase 2 - Build file tree (using nested annotations with filtering options)
@@ -91,7 +84,7 @@ func RenderAnnotatedTree(targetPath string, options RenderOptions) (*RenderResul
 	stats.TreeGenerated = true
 
 	if options.Verbose {
-		fmt.Fprintln(&outputBuilder, "=== File Tree Structure ===")
+		var treeStructureBuilder strings.Builder
 		err = tree.WalkTree(root, func(node *tree.Node, depth int) error {
 			indent := ""
 			for i := 0; i < depth; i++ {
@@ -112,49 +105,43 @@ func RenderAnnotatedTree(targetPath string, options RenderOptions) (*RenderResul
 				}
 			}
 
-			fmt.Fprintf(&outputBuilder, "%s%s (%s)%s\n", indent, node.Name, nodeType, annotationInfo)
+			fmt.Fprintf(&treeStructureBuilder, "%s%s (%s)%s\n", indent, node.Name, nodeType, annotationInfo)
 			return nil
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to walk tree: %w", err)
+			return nil, fmt.Errorf("failed to walk verbose tree: %w", err)
 		}
-		fmt.Fprintln(&outputBuilder, "=== End Tree Structure ===")
-		fmt.Fprintln(&outputBuilder)
+		verboseOutput.TreeStructure = treeStructureBuilder.String()
 	}
 
 	// Phase 3 - Render tree using the new RendererManager
-	if options.Verbose {
-		fmt.Fprintf(&outputBuilder, "treex analysis of: %s\n", targetPath)
-		fmt.Fprintf(&outputBuilder, "Found %d annotations\n", len(annotations))
-		fmt.Fprintln(&outputBuilder)
-	}
-
-	// Convert legacy options to new format system
 	renderRequest := format.RenderRequest{
 		Tree:          root,
 		Format:        parseFormat(options.Format),
 		Verbose:       false, // Tree rendering verbosity is separate from app verbosity
 		ShowStats:     false,
 		SafeMode:      options.SafeMode,
-		TerminalWidth: 80,
+		TerminalWidth: 80, // TODO: Consider making this dynamic or configurable
 		LegacyNoColor: options.NoColor,
 		LegacyMinimal: options.Minimal,
 	}
 
-	// Use the RendererManager for clean format selection and rendering
 	manager := format.GetDefaultManager()
 	renderResponse, err := manager.RenderTree(renderRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to render tree: %w", err)
 	}
 
-	// Append the rendered tree to our output
-	outputBuilder.WriteString(renderResponse.Output)
-
-	return &RenderResult{
-		Output: outputBuilder.String(),
+	result := &RenderResult{
+		Output: renderResponse.Output,
 		Stats:  stats,
-	}, nil
+	}
+
+	if options.Verbose {
+		result.VerboseOutput = verboseOutput
+	}
+
+	return result, nil
 }
 
 // parseFormat safely converts a format string to OutputFormat

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/adebert/treex/pkg/format" // Import the format package
 )
 
 func TestRenderAnnotatedTree_BasicFunctionality(t *testing.T) {
@@ -101,18 +103,67 @@ func TestRenderAnnotatedTree_VerboseMode(t *testing.T) {
 		t.Fatalf("RenderAnnotatedTree failed: %v", err)
 	}
 	
-	// In verbose mode, output should contain analysis information
+	// In verbose mode, the VerboseOutput field should be populated
+	if result.VerboseOutput == nil {
+		t.Fatal("Expected VerboseOutput to be populated in verbose mode")
+	}
+
+	if result.VerboseOutput.AnalyzedPath != tempDir {
+		t.Errorf("Expected AnalyzedPath to be %s, got %s", tempDir, result.VerboseOutput.AnalyzedPath)
+	}
+
+	if result.VerboseOutput.FoundAnnotations != 0 {
+		t.Errorf("Expected FoundAnnotations to be 0, got %d", result.VerboseOutput.FoundAnnotations)
+	}
+
+	if result.VerboseOutput.ParsedAnnotations == nil {
+		t.Error("Expected ParsedAnnotations to be non-nil (even if empty)")
+	}
+
+	// The main result.Output should NOT contain verbose strings anymore
 	output := result.Output
-	if !strings.Contains(output, "Analyzing directory:") {
-		t.Error("Expected verbose output to contain 'Analyzing directory:'")
+	if strings.Contains(output, "Analyzing directory:") {
+		t.Error("Expected result.Output NOT to contain 'Analyzing directory:'")
 	}
-	
-	if !strings.Contains(output, "=== Parsed Annotations ===") {
-		t.Error("Expected verbose output to contain annotations section")
+	if strings.Contains(output, "=== Parsed Annotations ===") {
+		t.Error("Expected result.Output NOT to contain annotations section")
 	}
-	
-	if !strings.Contains(output, "Found 0 annotations") {
-		t.Error("Expected verbose output to show annotation count")
+}
+
+func TestRenderAnnotatedTree_VerboseModeWithAnnotations(t *testing.T) {
+	tempDir := t.TempDir()
+	infoContent := "file.txt\nThis is a file."
+	infoPath := tempDir + "/.info"
+	if err := os.WriteFile(infoPath, []byte(infoContent), 0644); err != nil {
+		t.Fatalf("Failed to create test .info file: %v", err)
+	}
+	if _, err := os.Create(tempDir + "/file.txt"); err != nil {
+		t.Fatalf("Failed to create test file.txt: %v", err)
+	}
+
+	options := RenderOptions{
+		Verbose:    true,
+		NoColor:    true, // Kept for legacy path in RenderAnnotatedTree, though Format takes precedence
+		Format:     string(format.FormatNoColor), // Use format.FormatNoColor
+		SafeMode:   true,
+	}
+
+	result, err := RenderAnnotatedTree(tempDir, options)
+	if err != nil {
+		t.Fatalf("RenderAnnotatedTree failed: %v", err)
+	}
+
+	if result.VerboseOutput == nil {
+		t.Fatal("Expected VerboseOutput to be populated")
+	}
+	if result.VerboseOutput.FoundAnnotations != 1 {
+		t.Errorf("Expected FoundAnnotations to be 1, got %d", result.VerboseOutput.FoundAnnotations)
+	}
+	if _, ok := result.VerboseOutput.ParsedAnnotations["file.txt"]; !ok {
+		t.Error("Expected ParsedAnnotations to contain 'file.txt'")
+	}
+	if !strings.Contains(result.VerboseOutput.TreeStructure, "file.txt") {
+		t.Error("Expected VerboseOutput.TreeStructure to contain 'file.txt'")
 	}
 }
 

--- a/pkg/format/default.go
+++ b/pkg/format/default.go
@@ -36,6 +36,9 @@ func GetDefaultRegistry() *RendererRegistry {
 		_ = defaultRegistry.Register(NewHTMLRenderer())
 		_ = defaultRegistry.Register(NewCompactHTMLRenderer())
 		_ = defaultRegistry.Register(NewTableHTMLRenderer())
+
+		// Register SimpleList renderer
+		_ = defaultRegistry.Register(NewSimpleListRenderer())
 	})
 
 	return defaultRegistry

--- a/pkg/format/manager_test.go
+++ b/pkg/format/manager_test.go
@@ -395,3 +395,77 @@ func TestRenderTreeWithDefaults(t *testing.T) {
 		t.Error("RenderTreeWithDefaults() returned empty output")
 	}
 }
+
+func TestRendererManager_RenderTree_SimpleListFormat(t *testing.T) {
+	manager := NewRendererManager() // This will get the default registry with SimpleListRenderer
+
+	// Create a simple test tree
+	root := &tree.Node{
+		Name:  "project_root",
+		IsDir: true,
+		Children: []*tree.Node{
+			{
+				Name:  "file1.txt",
+				IsDir: false,
+			},
+			{
+				Name:  "docs",
+				IsDir: true,
+				Children: []*tree.Node{
+					{
+						Name:  "guide.md",
+						IsDir: false,
+					},
+				},
+			},
+			{
+				Name:  "file2.txt",
+				IsDir: false,
+			},
+		},
+	}
+
+	request := RenderRequest{
+		Tree:   root,
+		Format: FormatSimpleList, // Use the new format
+	}
+
+	response, err := manager.RenderTree(request)
+	if err != nil {
+		t.Fatalf("RenderTree() with FormatSimpleList failed: %v", err)
+	}
+
+	if response == nil {
+		t.Fatal("RenderTree() with FormatSimpleList returned nil response")
+	}
+
+	expectedOutput := `project_root/
+  file1.txt
+  docs/
+    guide.md
+  file2.txt
+`
+	if response.Output != expectedOutput {
+		t.Errorf("RenderTree() with FormatSimpleList incorrect output.\nExpected:\n%s\nGot:\n%s", expectedOutput, response.Output)
+	}
+
+	if response.Format != FormatSimpleList {
+		t.Errorf("Expected format %q, got %q", FormatSimpleList, response.Format)
+	}
+}
+
+// MockRenderer for testing purposes
+type MockRenderer struct {
+	format       OutputFormat
+	description  string
+	isTerminal   bool
+	renderOutput string
+	renderError  error
+}
+
+func (m *MockRenderer) Render(root *tree.Node, options RenderOptions) (string, error) {
+	return m.renderOutput, m.renderError
+}
+func (m *MockRenderer) Format() OutputFormat         { return m.format }
+func (m *MockRenderer) Description() string          { return m.description }
+func (m *MockRenderer) IsTerminalFormat() bool       { return m.isTerminal }

--- a/pkg/format/registry.go
+++ b/pkg/format/registry.go
@@ -33,6 +33,9 @@ const (
 	FormatHTML        OutputFormat = "html"
 	FormatCompactHTML OutputFormat = "compact-html"
 	FormatTableHTML   OutputFormat = "table-html"
+
+	// Custom Simple List Example
+	FormatSimpleList OutputFormat = "simplelist"
 )
 
 // RenderOptions contains configuration options for rendering
@@ -101,6 +104,9 @@ func NewRendererRegistry() *RendererRegistry {
 			"table-md":    FormatTableMarkdown,
 			"interactive": FormatHTML,
 			"compact-web": FormatCompactHTML,
+
+			// Alias for simplelist
+			"slist": FormatSimpleList,
 		},
 	}
 }

--- a/pkg/format/registry_test.go
+++ b/pkg/format/registry_test.go
@@ -7,26 +7,26 @@ import (
 	"github.com/adebert/treex/pkg/tree"
 )
 
-// MockRenderer for testing
-type MockRenderer struct {
+// RegistryMockRenderer for testing registry functionality
+type RegistryMockRenderer struct {
 	format      OutputFormat
 	description string
 	isTerminal  bool
 }
 
-func (m *MockRenderer) Render(root *tree.Node, options RenderOptions) (string, error) {
+func (m *RegistryMockRenderer) Render(root *tree.Node, options RenderOptions) (string, error) {
 	return "mock output for " + string(m.format), nil
 }
 
-func (m *MockRenderer) Format() OutputFormat {
+func (m *RegistryMockRenderer) Format() OutputFormat {
 	return m.format
 }
 
-func (m *MockRenderer) Description() string {
+func (m *RegistryMockRenderer) Description() string {
 	return m.description
 }
 
-func (m *MockRenderer) IsTerminalFormat() bool {
+func (m *RegistryMockRenderer) IsTerminalFormat() bool {
 	return m.isTerminal
 }
 
@@ -58,13 +58,13 @@ func TestRendererRegistry_Register(t *testing.T) {
 	registry := NewRendererRegistry()
 
 	// Test successful registration
-	mockRenderer := &MockRenderer{
+	registryMockRenderer := &RegistryMockRenderer{
 		format:      "test-format",
 		description: "Test format",
 		isTerminal:  true,
 	}
 
-	err := registry.Register(mockRenderer)
+	err := registry.Register(registryMockRenderer)
 	if err != nil {
 		t.Fatalf("Register() failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestRendererRegistry_Register(t *testing.T) {
 		t.Fatalf("GetRenderer() failed: %v", err)
 	}
 
-	if retrieved != mockRenderer {
+	if retrieved != registryMockRenderer {
 		t.Error("Retrieved renderer is not the same as registered")
 	}
 
@@ -86,7 +86,7 @@ func TestRendererRegistry_Register(t *testing.T) {
 	}
 
 	// Test registration with empty format
-	emptyFormatRenderer := &MockRenderer{format: "", description: "Empty"}
+	emptyFormatRenderer := &RegistryMockRenderer{format: "", description: "Empty"}
 	err = registry.Register(emptyFormatRenderer)
 	if err == nil {
 		t.Error("Expected error when registering renderer with empty format")
@@ -97,9 +97,9 @@ func TestRendererRegistry_ParseFormat(t *testing.T) {
 	registry := NewRendererRegistry()
 
 	// Register renderers for the formats we want to test aliases for
-	colorRenderer := &MockRenderer{format: FormatColor, description: "Color format", isTerminal: true}
-	minimalRenderer := &MockRenderer{format: FormatMinimal, description: "Minimal format", isTerminal: true}
-	testRenderer := &MockRenderer{format: "test", description: "Test format", isTerminal: true}
+	colorRenderer := &RegistryMockRenderer{format: FormatColor, description: "Color format", isTerminal: true}
+	minimalRenderer := &RegistryMockRenderer{format: FormatMinimal, description: "Minimal format", isTerminal: true}
+	testRenderer := &RegistryMockRenderer{format: "test", description: "Test format", isTerminal: true}
 
 	_ = registry.Register(colorRenderer)
 	_ = registry.Register(minimalRenderer)
@@ -161,12 +161,12 @@ func TestRendererRegistry_ListFormats(t *testing.T) {
 	registry := NewRendererRegistry()
 
 	// Register test renderers
-	renderers := []*MockRenderer{
+	testRenderers := []*RegistryMockRenderer{
 		{format: "format1", description: "Description 1", isTerminal: true},
 		{format: "format2", description: "Description 2", isTerminal: false},
 	}
 
-	for _, renderer := range renderers {
+	for _, renderer := range testRenderers {
 		_ = registry.Register(renderer)
 	}
 
@@ -189,14 +189,14 @@ func TestRendererRegistry_GetTerminalAndDataFormats(t *testing.T) {
 	registry := NewRendererRegistry()
 
 	// Register mixed renderers
-	renderers := []*MockRenderer{
+	testRenderers := []*RegistryMockRenderer{
 		{format: "terminal1", description: "Terminal 1", isTerminal: true},
 		{format: "terminal2", description: "Terminal 2", isTerminal: true},
 		{format: "data1", description: "Data 1", isTerminal: false},
 		{format: "data2", description: "Data 2", isTerminal: false},
 	}
 
-	for _, renderer := range renderers {
+	for _, renderer := range testRenderers {
 		_ = registry.Register(renderer)
 	}
 
@@ -236,8 +236,8 @@ func TestRendererRegistry_ValidateFormat(t *testing.T) {
 	registry := NewRendererRegistry()
 
 	// Register a test renderer
-	testRenderer := &MockRenderer{format: "test", description: "Test", isTerminal: true}
-	_ = registry.Register(testRenderer)
+	registryTestRenderer := &RegistryMockRenderer{format: "test", description: "Test", isTerminal: true}
+	_ = registry.Register(registryTestRenderer)
 
 	// Test valid format
 	err := registry.ValidateFormat("test")
@@ -270,8 +270,8 @@ func TestRendererRegistry_GetFormatHelp(t *testing.T) {
 	registry := NewRendererRegistry()
 
 	// Register mixed renderers
-	_ = registry.Register(&MockRenderer{format: "terminal", description: "Terminal format", isTerminal: true})
-	_ = registry.Register(&MockRenderer{format: "data", description: "Data format", isTerminal: false})
+	_ = registry.Register(&RegistryMockRenderer{format: "terminal", description: "Terminal format", isTerminal: true})
+	_ = registry.Register(&RegistryMockRenderer{format: "data", description: "Data format", isTerminal: false})
 
 	help := registry.GetFormatHelp()
 

--- a/pkg/format/simplelist_renderer.go
+++ b/pkg/format/simplelist_renderer.go
@@ -1,0 +1,50 @@
+package format
+
+import (
+	"strings"
+
+	"github.com/adebert/treex/pkg/tree"
+)
+
+// SimpleListRenderer renders trees as a simple indented list of names.
+type SimpleListRenderer struct{}
+
+// NewSimpleListRenderer creates a new SimpleListRenderer.
+func NewSimpleListRenderer() *SimpleListRenderer {
+	return &SimpleListRenderer{}
+}
+
+// Render implements the Renderer interface.
+func (r *SimpleListRenderer) Render(root *tree.Node, options RenderOptions) (string, error) {
+	var builder strings.Builder
+	r.renderNode(root, &builder, 0)
+	return builder.String(), nil
+}
+
+func (r *SimpleListRenderer) renderNode(node *tree.Node, builder *strings.Builder, depth int) {
+	builder.WriteString(strings.Repeat("  ", depth)) // Indentation
+	builder.WriteString(node.Name)
+	if node.IsDir {
+		builder.WriteString("/")
+	}
+	builder.WriteString("\n")
+
+	for _, child := range node.Children {
+		r.renderNode(child, builder, depth+1)
+	}
+}
+
+// Format implements the Renderer interface.
+func (r *SimpleListRenderer) Format() OutputFormat {
+	return FormatSimpleList // We'll define this constant next
+}
+
+// Description implements the Renderer interface.
+func (r *SimpleListRenderer) Description() string {
+	return "Simple indented list of file and directory names"
+}
+
+// IsTerminalFormat implements the Renderer interface.
+func (r *SimpleListRenderer) IsTerminalFormat() bool {
+	return true // Can be used in terminal, though it's plain
+}


### PR DESCRIPTION
…ut extensibility

- Modified RenderAnnotatedTree in pkg/app to return structured verbose data instead of pre-formatted strings.
- Moved verbose output formatting to the CLI layer in cmd/treex/cmd/show.go.
- Ensured cmd/treex/cmd/show.go uses cmd.OutOrStdout() for all output, enabling proper testing.
- Verified that the pkg/format system is extensible by adding a new 'simplelist' output format and its renderer.
- Updated tests in pkg/app and cmd/treex/cmd to reflect these changes and ensure correct behavior.
- Aligned .info file content in tests with the original parser's behavior regarding multi-line descriptions and titles.
- All existing and new tests are passing.