### PR TITLE
feat: Allow annotated files to override ignore patterns

### DIFF
--- a/cmd/treex/cmd/show.go
+++ b/cmd/treex/cmd/show.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/adebert/treex/pkg/app"
 	"github.com/adebert/treex/pkg/format"
@@ -85,10 +86,16 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create configuration from flags
+	// Resolve ignore file path relative to target path if it's a relative path
+	resolvedIgnoreFile := ignoreFile
+	if ignoreFile != "" && !filepath.IsAbs(ignoreFile) {
+		resolvedIgnoreFile = filepath.Join(targetPath, ignoreFile)
+	}
+
 	options := app.RenderOptions{
 		Verbose:    verbose,
 		Format:     outputFormat, // New format system
-		IgnoreFile: ignoreFile,
+		IgnoreFile: resolvedIgnoreFile,
 		MaxDepth:   maxDepth,
 		SafeMode:   safeMode,
 	}

--- a/pkg/tree/builder.go
+++ b/pkg/tree/builder.go
@@ -15,13 +15,13 @@ const MAX_FILES_PER_DIR = 10
 
 // Node represents a file or directory in the tree
 type Node struct {
-	Name        string            // Just the filename/dirname
-	Path        string            // Full path from root
+	Name         string           // Just the filename/dirname
+	Path         string           // Full path from root
 	RelativePath string           // Path relative to the tree root
-	IsDir       bool              // Whether this is a directory
-	Annotation  *info.Annotation  // Associated annotation if any
-	Children    []*Node           // Child nodes (for directories)
-	Parent      *Node             // Parent node (nil for root)
+	IsDir        bool             // Whether this is a directory
+	Annotation   *info.Annotation // Associated annotation if any
+	Children     []*Node          // Child nodes (for directories)
+	Parent       *Node            // Parent node (nil for root)
 }
 
 // Builder handles building file trees with annotations
@@ -48,7 +48,7 @@ func NewBuilderWithIgnore(rootPath string, annotations map[string]*info.Annotati
 	if err != nil {
 		return nil, fmt.Errorf("failed to load ignore file: %w", err)
 	}
-	
+
 	return &Builder{
 		rootPath:      rootPath,
 		annotations:   annotations,
@@ -61,14 +61,14 @@ func NewBuilderWithIgnore(rootPath string, annotations map[string]*info.Annotati
 func NewBuilderWithOptions(rootPath string, annotations map[string]*info.Annotation, ignoreFilePath string, maxDepth int) (*Builder, error) {
 	var ignoreMatcher *IgnoreMatcher
 	var err error
-	
+
 	if ignoreFilePath != "" {
 		ignoreMatcher, err = NewIgnoreMatcher(ignoreFilePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load ignore file: %w", err)
 		}
 	}
-	
+
 	return &Builder{
 		rootPath:      rootPath,
 		annotations:   annotations,
@@ -139,7 +139,7 @@ func (b *Builder) buildChildren(parent *Node, depth int) error {
 			if entry.Name() == ".info" {
 				continue
 			}
-			
+
 			// Check if this hidden file/dir has an annotation
 			relativePath := filepath.Join(parent.RelativePath, entry.Name())
 			if parent.RelativePath == "." {
@@ -151,7 +151,7 @@ func (b *Builder) buildChildren(parent *Node, depth int) error {
 		}
 
 		childRelativePath := filepath.Join(parent.RelativePath, entry.Name())
-		
+
 		// Normalize relative path for root directory
 		if parent.RelativePath == "." {
 			childRelativePath = entry.Name()
@@ -161,7 +161,12 @@ func (b *Builder) buildChildren(parent *Node, depth int) error {
 		if b.ignoreMatcher != nil && b.ignoreMatcher.ShouldIgnore(childRelativePath, entry.IsDir()) {
 			// Skip ignored files unless they have annotations
 			if _, hasAnnotation := b.annotations[childRelativePath]; !hasAnnotation {
-				continue
+				// For directories, also check if any nested paths have annotations
+				if entry.IsDir() && b.hasNestedAnnotations(childRelativePath) {
+					// Directory has nested annotations, don't skip it
+				} else {
+					continue
+				}
 			}
 		}
 
@@ -190,7 +195,7 @@ func (b *Builder) buildChildren(parent *Node, depth int) error {
 	for _, entry := range filteredEntries {
 		childPath := filepath.Join(parent.Path, entry.Name())
 		childRelativePath := filepath.Join(parent.RelativePath, entry.Name())
-		
+
 		// Normalize relative path for root directory
 		if parent.RelativePath == "." {
 			childRelativePath = entry.Name()
@@ -253,6 +258,25 @@ func (b *Builder) getAnnotation(relativePath string) *info.Annotation {
 	return nil
 }
 
+// hasNestedAnnotations checks if there are any annotations for paths nested under the given directory path
+func (b *Builder) hasNestedAnnotations(dirPath string) bool {
+	// Normalize the directory path
+	dirPath = filepath.ToSlash(dirPath)
+	if !strings.HasSuffix(dirPath, "/") {
+		dirPath += "/"
+	}
+
+	// Check if any annotation path starts with this directory path
+	for annotationPath := range b.annotations {
+		annotationPath = filepath.ToSlash(annotationPath)
+		if strings.HasPrefix(annotationPath, dirPath) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // BuildTree is a convenience function that combines parsing and building (single .info file)
 func BuildTree(rootPath string) (*Node, error) {
 	// Parse annotations from the root directory only
@@ -293,7 +317,7 @@ func BuildTreeNestedWithIgnore(rootPath, ignoreFilePath string) (*Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return builder.Build()
 }
 
@@ -310,7 +334,7 @@ func BuildTreeNestedWithOptions(rootPath, ignoreFilePath string, maxDepth int) (
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return builder.Build()
 }
 
@@ -324,13 +348,13 @@ func walkTree(node *Node, depth int, fn func(*Node, int) error) error {
 	if err := fn(node, depth); err != nil {
 		return err
 	}
-	
+
 	for _, child := range node.Children {
 		if err := walkTree(child, depth+1, fn); err != nil {
 			return err
 		}
 	}
-	
+
 	return nil
 }
 
@@ -342,4 +366,4 @@ type DisplayConfig struct {
 	IgnoreFile string
 	MaxDepth   int
 	SafeMode   bool
-} 
+}

--- a/pkg/tree/builder_test.go
+++ b/pkg/tree/builder_test.go
@@ -685,3 +685,171 @@ func TestBuildTreeNestedWithOptions(t *testing.T) {
 		t.Error("Did not expect to find file3.txt (beyond depth limit)")
 	}
 }
+
+func TestBuilder_IgnoreWithAnnotationsOverride(t *testing.T) {
+	// Test that files with annotations are shown even if they match ignore patterns
+	tempDir := t.TempDir()
+
+	// Create test files and directories
+	testFiles := []string{
+		"README.md",
+		"main.go",
+		"debug.log",
+		"ignored.tmp",
+		".venv/pyvenv.cfg",
+		".venv/lib/python3.9/site-packages/requests/__init__.py",
+		"build/output.bin",
+		"src/app.go",
+		"src/test.log",
+		"node_modules/package/index.js",
+	}
+
+	for _, file := range testFiles {
+		fullPath := filepath.Join(tempDir, file)
+		dir := filepath.Dir(fullPath)
+
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			t.Fatalf("Failed to create directory %s: %v", dir, err)
+		}
+
+		err = os.WriteFile(fullPath, []byte("test content"), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create file %s: %v", fullPath, err)
+		}
+	}
+
+	// Create .gitignore with patterns that would normally exclude some files
+	ignoreFile := filepath.Join(tempDir, ".gitignore")
+	ignoreContent := `*.log
+*.tmp
+.venv/
+build/
+node_modules/
+`
+
+	err := os.WriteFile(ignoreFile, []byte(ignoreContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create .gitignore: %v", err)
+	}
+
+	// Create annotations for some files that would normally be ignored
+	annotations := map[string]*info.Annotation{
+		"debug.log": {
+			Path:        "debug.log",
+			Title:       "Debug Log File",
+			Description: "Debug Log File\nContains application debug information",
+		},
+		".venv": {
+			Path:        ".venv",
+			Title:       "Python Virtual Environment",
+			Description: "Python Virtual Environment\nContains isolated Python dependencies for this project",
+		},
+		"ignored.tmp": {
+			Path:        "ignored.tmp",
+			Title:       "Temporary Work File",
+			Description: "Temporary Work File\nUsed for intermediate processing",
+		},
+		"build/output.bin": {
+			Path:        "build/output.bin",
+			Title:       "Build Output",
+			Description: "Build Output\nCompiled binary from the build process",
+		},
+	}
+
+	// Build tree with annotations and ignore support
+	builder, err := NewBuilderWithIgnore(tempDir, annotations, ignoreFile)
+	if err != nil {
+		t.Fatalf("Failed to create builder: %v", err)
+	}
+
+	root, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Failed to build tree with ignore: %v", err)
+	}
+
+	// Collect all files found in the tree
+	foundFiles := make(map[string]bool)
+	foundDirs := make(map[string]bool)
+	err = WalkTree(root, func(node *Node, depth int) error {
+		if node.IsDir {
+			if node.RelativePath != "." {
+				foundDirs[node.RelativePath] = true
+			}
+		} else {
+			foundFiles[node.RelativePath] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to walk tree: %v", err)
+	}
+
+	// Files that should be present (either not ignored or have annotations)
+	expectedPresent := []string{
+		"README.md",        // not ignored
+		"main.go",          // not ignored
+		"debug.log",        // ignored by *.log BUT has annotation - should be present
+		"ignored.tmp",      // ignored by *.tmp BUT has annotation - should be present
+		"build/output.bin", // ignored by build/ BUT has annotation - should be present
+		"src/app.go",       // not ignored
+	}
+
+	// Directories that should be present
+	expectedPresentDirs := []string{
+		".venv", // ignored by .venv/ BUT has annotation - should be present
+		"src",   // not ignored
+		"build", // directory itself should be present since build/output.bin has annotation
+	}
+
+	// Files that should NOT be present (ignored and no annotations)
+	expectedAbsent := []string{
+		"src/test.log",     // ignored by *.log and no annotation
+		".venv/pyvenv.cfg", // ignored by .venv/ and no annotation
+		".venv/lib/python3.9/site-packages/requests/__init__.py", // ignored by .venv/ and no annotation
+		"node_modules/package/index.js",                          // ignored by node_modules/ and no annotation
+	}
+
+	// Verify expected present files
+	for _, file := range expectedPresent {
+		if !foundFiles[file] {
+			t.Errorf("Expected file %s to be present (should override ignore due to annotation) but it was filtered out", file)
+		}
+	}
+
+	// Verify expected present directories
+	for _, dir := range expectedPresentDirs {
+		if !foundDirs[dir] {
+			t.Errorf("Expected directory %s to be present (should override ignore due to annotation) but it was filtered out", dir)
+		}
+	}
+
+	// Verify expected absent files
+	for _, file := range expectedAbsent {
+		if foundFiles[file] {
+			t.Errorf("Expected file %s to be filtered out (ignored and no annotation) but it was present", file)
+		}
+	}
+
+	// Verify that annotated files have their annotations
+	err = WalkTree(root, func(node *Node, depth int) error {
+		if node.RelativePath == "debug.log" {
+			if node.Annotation == nil {
+				t.Error("debug.log should have annotation")
+			} else if node.Annotation.Title != "Debug Log File" {
+				t.Errorf("debug.log annotation title mismatch: got %q", node.Annotation.Title)
+			}
+		}
+		if node.RelativePath == ".venv" {
+			if node.Annotation == nil {
+				t.Error(".venv should have annotation")
+			} else if node.Annotation.Title != "Python Virtual Environment" {
+				t.Errorf(".venv annotation title mismatch: got %q", node.Annotation.Title)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to verify annotations: %v", err)
+	}
+}


### PR DESCRIPTION
- Add support for showing files/directories with .info annotations even when they match ignore patterns
- Fix ignore file path resolution to be relative to target directory instead of current working directory
- Add hasNestedAnnotations() helper to check for annotations in ignored directory children
- Add comprehensive test coverage for ignore pattern override behavior
- Fixes use case where users want to document .venv, build artifacts, or other ignored files

This enables documenting typically ignored paths (like .venv/) in .info files and having them displayed regardless of gitignore patterns, while still filtering out unannotated ignored files.
