### PR TITLE
Fix tree connector alignment in multi-line annotations

### DIFF
--- a/cmd/treex/cmd/show_integration_test.go
+++ b/cmd/treex/cmd/show_integration_test.go
@@ -1,0 +1,374 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestShowCmd_Integration_BasicTree(t *testing.T) {
+	// Create a test directory structure
+	tempDir := t.TempDir()
+	
+	// Create directory structure
+	dirs := []string{
+		"src",
+		"src/utils",
+		"docs",
+		"tests",
+	}
+	
+	for _, dir := range dirs {
+		if err := os.MkdirAll(filepath.Join(tempDir, dir), 0755); err != nil {
+			t.Fatalf("Failed to create directory %s: %v", dir, err)
+		}
+	}
+	
+	// Create files
+	files := []string{
+		"README.md",
+		"main.go",
+		"src/app.go",
+		"src/utils/helper.go",
+		"docs/guide.md",
+		"tests/app_test.go",
+	}
+	
+	for _, file := range files {
+		fullPath := filepath.Join(tempDir, file)
+		if err := os.WriteFile(fullPath, []byte("test content"), 0644); err != nil {
+			t.Fatalf("Failed to create file %s: %v", file, err)
+		}
+	}
+	
+	// Create .info file with annotations
+	infoContent := `README.md Project documentation
+The main readme file for the project
+
+main.go Application entry point
+The main function that starts the application
+
+src/app.go Core application logic
+
+docs/guide.md User guide
+Comprehensive guide for users`
+	
+	if err := os.WriteFile(filepath.Join(tempDir, ".info"), []byte(infoContent), 0644); err != nil {
+		t.Fatalf("Failed to create .info file: %v", err)
+	}
+	
+	// Run the show command
+	resetGlobalFlags()
+	testRootCmd := &cobra.Command{Use: "treex"}
+	testShowCmd := setupShowCmd()
+	testRootCmd.AddCommand(testShowCmd)
+	
+	output, err := executeCommand(testRootCmd, "show", tempDir, "--format=no-color")
+	if err != nil {
+		t.Fatalf("Show command failed: %v", err)
+	}
+	
+	// Verify the output contains expected elements
+	expectedElements := []string{
+		"README.md",
+		"Project documentation",
+		"main.go",
+		"Application entry point",
+		"src",
+		"app.go",
+		"Core application logic",
+		"docs",
+		"guide.md",
+		"User guide",
+		"tests", // Directory shows but contents might not in mix mode
+	}
+	
+	// The directory name in output will be the temp dir name, not our choice
+	// So we check for file names and structure instead
+	
+	for _, elem := range expectedElements {
+		if !strings.Contains(output, elem) {
+			t.Errorf("Expected output to contain '%s'.\nFull output:\n%s", elem, output)
+		}
+	}
+	
+	// Verify tree structure connectors
+	if !strings.Contains(output, "├──") || !strings.Contains(output, "└──") {
+		t.Errorf("Expected output to contain tree connectors (├──, └──).\nFull output:\n%s", output)
+	}
+}
+
+func TestShowCmd_Integration_ViewModes(t *testing.T) {
+	// Create a test directory structure with many files
+	tempDir := t.TempDir()
+	
+	// Create many files to test view modes
+	annotatedFiles := map[string]string{
+		"important1.go": "Critical file 1",
+		"important2.go": "Critical file 2",
+		"src/core.go":   "Core functionality",
+	}
+	
+	// Create annotated files
+	for file := range annotatedFiles {
+		fullPath := filepath.Join(tempDir, file)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		if err := os.WriteFile(fullPath, []byte("content"), 0644); err != nil {
+			t.Fatalf("Failed to create file %s: %v", file, err)
+		}
+	}
+	
+	// Create many unannotated files
+	for i := 1; i <= 10; i++ {
+		filename := fmt.Sprintf("file%d.txt", i)
+		if err := os.WriteFile(filepath.Join(tempDir, filename), []byte("content"), 0644); err != nil {
+			t.Fatalf("Failed to create file %s: %v", filename, err)
+		}
+	}
+	
+	// Create .info file
+	var infoLines []string
+	for file, desc := range annotatedFiles {
+		infoLines = append(infoLines, fmt.Sprintf("%s %s", file, desc))
+	}
+	infoContent := strings.Join(infoLines, "\n\n")
+	
+	if err := os.WriteFile(filepath.Join(tempDir, ".info"), []byte(infoContent), 0644); err != nil {
+		t.Fatalf("Failed to create .info file: %v", err)
+	}
+	
+	testCases := []struct {
+		name           string
+		viewMode       string
+		shouldContain  []string
+		shouldNotContain []string
+	}{
+		{
+			name:     "annotated mode",
+			viewMode: "annotated",
+			shouldContain: []string{
+				"important1.go",
+				"important2.go",
+				"core.go",
+				"Critical file 1",
+				"treex --show all to see all paths",
+			},
+			shouldNotContain: []string{
+				"file1.txt",
+				"file5.txt",
+			},
+		},
+		{
+			name:     "all mode",
+			viewMode: "all",
+			shouldContain: []string{
+				"important1.go",
+				"file1.txt",
+				"file10.txt",
+				"Critical file 1",
+			},
+			shouldNotContain: []string{
+				"more items",
+				"treex --show all",
+			},
+		},
+		{
+			name:     "mix mode",
+			viewMode: "mix",
+			shouldContain: []string{
+				"important1.go",
+				"Critical file 1",
+				"file1.txt", // Some context files
+				"more items", // Should have "more items" indicator
+			},
+			shouldNotContain: []string{
+				"file7.txt", // Shouldn't show files beyond context limit (6 unannotated + 2 annotated)
+				"file8.txt", // Shouldn't show files beyond context limit
+				"treex --show all",
+			},
+		},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetGlobalFlags()
+			testRootCmd := &cobra.Command{Use: "treex"}
+			testShowCmd := setupShowCmd()
+			testRootCmd.AddCommand(testShowCmd)
+			
+			output, err := executeCommand(testRootCmd, "show", tempDir, "--format=no-color", "--show="+tc.viewMode)
+			if err != nil {
+				t.Fatalf("Show command failed: %v", err)
+			}
+			
+			// Check elements that should be present
+			for _, elem := range tc.shouldContain {
+				if !strings.Contains(output, elem) {
+					t.Errorf("Expected output to contain '%s' in %s mode.\nFull output:\n%s", 
+						elem, tc.viewMode, output)
+				}
+			}
+			
+			// Check elements that should NOT be present
+			for _, elem := range tc.shouldNotContain {
+				if strings.Contains(output, elem) {
+					t.Errorf("Expected output NOT to contain '%s' in %s mode.\nFull output:\n%s", 
+						elem, tc.viewMode, output)
+				}
+			}
+		})
+	}
+}
+
+func TestShowCmd_Integration_MultiLineAnnotations(t *testing.T) {
+	// Test that multi-line annotations are rendered correctly
+	tempDir := t.TempDir()
+	
+	// Create a file
+	if err := os.WriteFile(filepath.Join(tempDir, "complex.go"), []byte("content"), 0644); err != nil {
+		t.Fatalf("Failed to create file: %v", err)
+	}
+	
+	// Create .info file with multi-line annotation  
+	infoContent := `complex.go Complex component
+This component handles multiple responsibilities:
+- User authentication
+- Session management
+- Access control
+It's a critical part of the system.`
+	
+	if err := os.WriteFile(filepath.Join(tempDir, ".info"), []byte(infoContent), 0644); err != nil {
+		t.Fatalf("Failed to create .info file: %v", err)
+	}
+	
+	resetGlobalFlags()
+	testRootCmd := &cobra.Command{Use: "treex"}
+	testShowCmd := setupShowCmd()
+	testRootCmd.AddCommand(testShowCmd)
+	
+	output, err := executeCommand(testRootCmd, "show", tempDir, "--format=no-color")
+	if err != nil {
+		t.Fatalf("Show command failed: %v", err)
+	}
+	
+	// Check that the title appears only once
+	titleCount := strings.Count(output, "Complex component")
+	if titleCount != 1 {
+		t.Errorf("Expected title to appear exactly once, found %d times.\nFull output:\n%s", 
+			titleCount, output)
+	}
+	
+	// Check that multi-line content is present
+	expectedLines := []string{
+		"This component handles multiple responsibilities:",
+		"- User authentication",
+		"- Session management", 
+		"- Access control",
+		"It's a critical part of the system.",
+	}
+	
+	for _, line := range expectedLines {
+		if !strings.Contains(output, line) {
+			t.Errorf("Expected output to contain '%s'.\nFull output:\n%s", line, output)
+		}
+	}
+}
+
+func TestShowCmd_Integration_DeepNesting(t *testing.T) {
+	// Test deeply nested directory structures
+	tempDir := t.TempDir()
+	
+	// Create deep directory structure
+	deepPath := "src/internal/core/handlers/api/v2"
+	if err := os.MkdirAll(filepath.Join(tempDir, deepPath), 0755); err != nil {
+		t.Fatalf("Failed to create deep directory: %v", err)
+	}
+	
+	// Create file at various levels
+	files := []string{
+		"README.md",
+		"src/main.go",
+		"src/internal/utils.go",
+		"src/internal/core/engine.go",
+		filepath.Join(deepPath, "handler.go"),
+	}
+	
+	for _, file := range files {
+		if err := os.WriteFile(filepath.Join(tempDir, file), []byte("content"), 0644); err != nil {
+			t.Fatalf("Failed to create file %s: %v", file, err)
+		}
+	}
+	
+	// Create .info with annotations at different levels
+	infoContent := `README.md Project root documentation
+
+src/main.go Main entry point
+
+src/internal/core/engine.go Core processing engine
+The heart of the application`
+	
+	if err := os.WriteFile(filepath.Join(tempDir, ".info"), []byte(infoContent), 0644); err != nil {
+		t.Fatalf("Failed to create .info file: %v", err)
+	}
+	
+	// Also create a nested .info file
+	nestedInfoContent := `handler.go API v2 handler
+Handles all v2 API requests`
+	
+	if err := os.WriteFile(filepath.Join(tempDir, deepPath, ".info"), []byte(nestedInfoContent), 0644); err != nil {
+		t.Fatalf("Failed to create nested .info file: %v", err)
+	}
+	
+	resetGlobalFlags()
+	testRootCmd := &cobra.Command{Use: "treex"}
+	testShowCmd := setupShowCmd()
+	testRootCmd.AddCommand(testShowCmd)
+	
+	output, err := executeCommand(testRootCmd, "show", tempDir, "--format=no-color")
+	if err != nil {
+		t.Fatalf("Show command failed: %v", err)
+	}
+	
+	// Verify deep nesting is shown correctly
+	expectedElements := []string{
+		"src",
+		"internal",
+		"core", 
+		"handlers",
+		"api",
+		"v2",
+		"handler.go",
+		"API v2 handler",
+		"engine.go",
+		"Core processing engine",
+	}
+	
+	for _, elem := range expectedElements {
+		if !strings.Contains(output, elem) {
+			t.Errorf("Expected output to contain '%s'.\nFull output:\n%s", elem, output)
+		}
+	}
+	
+	// Verify proper indentation (more │ characters = deeper nesting)
+	lines := strings.Split(output, "\n")
+	var v2Line string
+	for _, line := range lines {
+		if strings.Contains(line, "handler.go") && strings.Contains(line, "API v2 handler") {
+			v2Line = line
+			break
+		}
+	}
+	
+	// Count tree characters to verify deep nesting
+	treeChars := strings.Count(v2Line, "│")
+	if treeChars < 4 { // Should have at least 4 levels of nesting
+		t.Errorf("Expected deep nesting (at least 4 │ chars), found %d in line: %s", treeChars, v2Line)
+	}
+}

--- a/cmd/treex/cmd/show_test.go
+++ b/cmd/treex/cmd/show_test.go
@@ -34,6 +34,7 @@ func resetGlobalFlags() {
 	verbose = false
 	path = ""
 	outputFormat = "color"
+	showMode = "mix"
 	ignoreFile = ".gitignore"
 	maxDepth = 10
 	safeMode = false
@@ -56,6 +57,7 @@ func setupShowCmd() *cobra.Command {
 	testShowCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show verbose output")
 	testShowCmd.Flags().StringVarP(&path, "path", "p", "", "Path to analyze")
 	testShowCmd.Flags().StringVar(&outputFormat, "format", "color", "Output format")
+	testShowCmd.Flags().StringVar(&showMode, "show", "mix", "View mode: mix, annotated, all")
 	testShowCmd.Flags().StringVar(&ignoreFile, "use-ignore-file", ".gitignore", "Use specified ignore file")
 	testShowCmd.Flags().IntVarP(&maxDepth, "depth", "d", 10, "Maximum depth to traverse")
 	testShowCmd.Flags().BoolVar(&safeMode, "safe-mode", false, "Force safe terminal rendering mode")

--- a/pkg/tui/connector_alignment_test.go
+++ b/pkg/tui/connector_alignment_test.go
@@ -1,0 +1,259 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/adebert/treex/pkg/info"
+	"github.com/adebert/treex/pkg/tree"
+)
+
+func TestRenderer_ConnectorAlignment(t *testing.T) {
+	// Create a deeply nested tree structure
+	root := &tree.Node{
+		Name:  "root",
+		IsDir: true,
+		Children: []*tree.Node{
+			{
+				Name:  "cmd",
+				IsDir: true,
+				Children: []*tree.Node{
+					{
+						Name:  "app",
+						IsDir: true,
+						Children: []*tree.Node{
+							{
+								Name:  "handler.go",
+								IsDir: false,
+								Annotation: &info.Annotation{
+									Title:       "Request handler",
+									Description: "Request handler\nHandles HTTP requests and routes them appropriately",
+								},
+							},
+							{
+								Name:  "subdir",
+								IsDir: true,
+								Children: []*tree.Node{
+									{
+										Name:  "util.go",
+										IsDir: false,
+										Annotation: &info.Annotation{
+											Title:       "Utility functions",
+											Description: "Utility functions\nHelper functions used throughout the application",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Name:  "root.go",
+						IsDir: false,
+						Annotation: &info.Annotation{
+							Title:       "Root command",
+							Description: "Root command\nSets up the CLI root command",
+						},
+					},
+				},
+			},
+			{
+				Name:  "main.go",
+				IsDir: false,
+				Annotation: &info.Annotation{
+					Title:       "Main entry",
+					Description: "Main entry\nBootstrap code",
+				},
+			},
+		},
+	}
+
+	// Test with plain renderer
+	output, err := RenderTreeToString(root, true)
+	if err != nil {
+		t.Fatalf("Failed to render tree: %v", err)
+	}
+
+	// Split output into lines for analysis
+	lines := strings.Split(output, "\n")
+
+	// Find the description lines and check their prefixes
+	for i, line := range lines {
+		// Check for handler.go's description line
+		if strings.Contains(line, "Handles HTTP requests") {
+			// Count the number of │ characters at the start
+			prefix := extractPrefix(line)
+			// handler.go is at cmd/app/handler.go
+			// The file line shows: │   │   ├── handler.go
+			// So the description continuation should be: │   │   │
+			expectedConnectors := 3 // Should have 3 │ connectors
+			actualConnectors := strings.Count(prefix, "│")
+			
+			if actualConnectors != expectedConnectors {
+				t.Logf("DEBUG: Previous line: %s", lines[i-1])
+				t.Errorf("handler.go description: expected %d │ connectors, got %d\nLine: %s\nPrefix: %q", 
+					expectedConnectors, actualConnectors, line, prefix)
+			}
+		}
+
+		// Check for util.go's description line
+		if strings.Contains(line, "Helper functions used") {
+			// Count the number of │ characters at the start
+			prefix := extractPrefix(line)
+			// util.go is at cmd/app/subdir/util.go
+			// When rendered, subdir passes its continuation prefix to children
+			// Since subdir is the last child of app, its continuation uses spaces
+			// So util.go's description gets the prefix from subdir's context
+			expectedConnectors := 2 // Has 2 │ connectors from the parent context
+			actualConnectors := strings.Count(prefix, "│")
+			
+			if actualConnectors != expectedConnectors {
+				t.Logf("DEBUG: Previous line: %s", lines[i-1])
+				t.Errorf("util.go description: expected %d │ connectors, got %d\nLine: %s\nPrefix: %q", 
+					expectedConnectors, actualConnectors, line, prefix)
+			}
+		}
+
+		// Check for main.go's description line
+		if strings.Contains(line, "Bootstrap code") && i > 0 {
+			prefix := extractPrefix(line)
+			expectedConnectors := 0 // At root level, no │ connectors
+			actualConnectors := strings.Count(prefix, "│")
+			
+			if actualConnectors != expectedConnectors {
+				t.Errorf("main.go description: expected %d │ connectors, got %d\nLine: %s\nPrefix: %q", 
+					expectedConnectors, actualConnectors, line, prefix)
+			}
+		}
+	}
+}
+
+func TestStyledRenderer_ConnectorAlignment(t *testing.T) {
+	// Create a tree with multiple levels
+	root := &tree.Node{
+		Name:  "project",
+		IsDir: true,
+		Children: []*tree.Node{
+			{
+				Name:  "src",
+				IsDir: true,
+				Children: []*tree.Node{
+					{
+						Name:  "core",
+						IsDir: true,
+						Children: []*tree.Node{
+							{
+								Name:  "engine.go",
+								IsDir: false,
+								Annotation: &info.Annotation{
+									Title:       "Core engine",
+									Description: "Core engine\nThe main processing engine\nHandles all core operations",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:  "docs",
+				IsDir: true,
+				Children: []*tree.Node{
+					{
+						Name:  "api.md",
+						IsDir: false,
+						Annotation: &info.Annotation{
+							Title:       "API documentation",
+							Description: "API documentation\nComprehensive API reference",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Test with styled renderer
+	output, err := RenderStyledTreeToString(root, true)
+	if err != nil {
+		t.Fatalf("Failed to render tree: %v", err)
+	}
+
+	// Remove ANSI codes for easier testing
+	cleanOutput := stripANSIForTest(output)
+	lines := strings.Split(cleanOutput, "\n")
+
+	// Check engine.go's multi-line description
+	for _, line := range lines {
+		if strings.Contains(line, "The main processing engine") {
+			prefix := extractPrefix(line)
+			// Should maintain tree structure with proper indentation
+			if !strings.Contains(prefix, "│") || len(prefix) < 2 {
+				t.Errorf("Multi-line description lost tree structure.\nLine: %s\nPrefix: %q", line, prefix)
+			}
+		}
+		
+		// Check the third line of engine.go description
+		if strings.Contains(line, "Handles all core operations") {
+			prefix := extractPrefix(line)
+			// Count │ characters - should match the tree depth
+			// engine.go is at project/src/core/engine.go
+			// Since core is the last child of src (└──), its continuation only has 1 │ from project level
+			connectorCount := strings.Count(prefix, "│")
+			expectedCount := 1
+			if connectorCount != expectedCount {
+				t.Errorf("Third line of description has incorrect connectors: expected %d, got %d\nLine: %s", 
+					expectedCount, connectorCount, line)
+			}
+		}
+	}
+}
+
+// extractPrefix extracts the prefix (indentation and tree characters) from a line
+func extractPrefix(line string) string {
+	// Find where the actual content starts (first alphanumeric character)
+	for i, ch := range line {
+		if (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') {
+			return line[:i]
+		}
+	}
+	return line
+}
+
+// stripANSIForTest removes ANSI escape codes for testing
+func stripANSIForTest(text string) string {
+	// More comprehensive ANSI stripping that handles various escape sequences
+	var result strings.Builder
+	i := 0
+	
+	for i < len(text) {
+		// Check for ESC character (0x1B)
+		if i < len(text)-1 && text[i] == '\x1b' {
+			// Skip the ESC character
+			i++
+			
+			// Handle CSI sequences (ESC[)
+			if i < len(text) && text[i] == '[' {
+				i++ // Skip [
+				// Skip until we find a letter (command character)
+				for i < len(text) {
+					ch := text[i]
+					i++
+					// CSI sequences end with a letter
+					if (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') {
+						break
+					}
+				}
+			} else if i < len(text) && (text[i] == '(' || text[i] == ')') {
+				// Handle other escape sequences like ESC( or ESC)
+				i++ // Skip the ( or )
+				if i < len(text) {
+					i++ // Skip the next character
+				}
+			}
+		} else {
+			// Regular character, add to result
+			result.WriteByte(text[i])
+			i++
+		}
+	}
+	
+	return result.String()
+}

--- a/pkg/tui/duplicate_title_test.go
+++ b/pkg/tui/duplicate_title_test.go
@@ -1,0 +1,154 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/adebert/treex/pkg/info"
+	"github.com/adebert/treex/pkg/tree"
+)
+
+func TestStyledRenderer_NoDuplicateTitle(t *testing.T) {
+	// Create a root node with a child that has annotations
+	root := &tree.Node{
+		Name:  "scripts",
+		IsDir: true,
+		Children: []*tree.Node{
+			{
+				Name:  "build",
+				IsDir: false,
+				Annotation: &info.Annotation{
+					Title:       "Build script for treex",
+					Description: "Build script for treex\nCompiles the treex binary and places it in bin/treex",
+				},
+				Children: []*tree.Node{},
+			},
+		},
+	}
+
+	// Test with styled renderer
+	output, err := RenderStyledTreeToString(root, true)
+	if err != nil {
+		t.Fatalf("Failed to render tree: %v", err)
+	}
+
+	// Count occurrences of the title
+	titleCount := strings.Count(output, "Build script for treex")
+	if titleCount > 1 {
+		t.Errorf("Title appears %d times, expected 1.\nOutput:\n%s", titleCount, output)
+	}
+
+	// The description line should appear exactly once
+	descCount := strings.Count(output, "Compiles the treex binary")
+	if descCount != 1 {
+		t.Errorf("Description appears %d times, expected 1.\nOutput:\n%s", descCount, output)
+	}
+}
+
+func TestPlainRenderer_NoDuplicateTitle(t *testing.T) {
+	// Create a root node with a child that has annotations
+	root := &tree.Node{
+		Name:  "scripts",
+		IsDir: true,
+		Children: []*tree.Node{
+			{
+				Name:  "build",
+				IsDir: false,
+				Annotation: &info.Annotation{
+					Title:       "Build script for treex",
+					Description: "Build script for treex\nCompiles the treex binary and places it in bin/treex",
+				},
+				Children: []*tree.Node{},
+			},
+		},
+	}
+
+	// Test with plain renderer
+	output, err := RenderTreeToString(root, true)
+	if err != nil {
+		t.Fatalf("Failed to render tree: %v", err)
+	}
+
+	// Count occurrences of the title
+	titleCount := strings.Count(output, "Build script for treex")
+	if titleCount > 1 {
+		t.Errorf("Title appears %d times, expected 1.\nOutput:\n%s", titleCount, output)
+	}
+
+	// The description line should appear exactly once
+	descCount := strings.Count(output, "Compiles the treex binary")
+	if descCount != 1 {
+		t.Errorf("Description appears %d times, expected 1.\nOutput:\n%s", descCount, output)
+	}
+}
+
+func TestRenderer_ComplexAnnotations(t *testing.T) {
+	// Test various annotation scenarios
+	testCases := []struct {
+		name        string
+		annotation  *info.Annotation
+		shouldShow  []string    // Lines that should appear
+		shouldNotShow []string  // Lines that should NOT appear (duplicates)
+	}{
+		{
+			name: "Title with multi-line description",
+			annotation: &info.Annotation{
+				Title:       "Main title",
+				Description: "Main title\nSecond line\nThird line",
+			},
+			shouldShow: []string{"Main title", "Second line", "Third line"},
+			shouldNotShow: []string{}, // No duplicates expected
+		},
+		{
+			name: "Title only (same as description)",
+			annotation: &info.Annotation{
+				Title:       "Single line annotation",
+				Description: "Single line annotation",
+			},
+			shouldShow: []string{"Single line annotation"},
+			shouldNotShow: []string{}, // Should appear only once
+		},
+		{
+			name: "No title, multi-line description",
+			annotation: &info.Annotation{
+				Title:       "",
+				Description: "First line is the title\nSecond line is detail",
+			},
+			shouldShow: []string{"First line is the title", "Second line is detail"},
+			shouldNotShow: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a root with the annotated child
+			root := &tree.Node{
+				Name:  "root",
+				IsDir: true,
+				Children: []*tree.Node{
+					{
+						Name:       "test",
+						IsDir:      false,
+						Annotation: tc.annotation,
+						Children:   []*tree.Node{},
+					},
+				},
+			}
+
+			// Test styled renderer
+			output, err := RenderStyledTreeToString(root, true)
+			if err != nil {
+				t.Fatalf("Failed to render tree: %v", err)
+			}
+
+			// Check that expected lines appear
+			for _, line := range tc.shouldShow {
+				count := strings.Count(output, line)
+				if count != 1 {
+					t.Errorf("Expected line '%s' to appear exactly once, found %d times.\nOutput:\n%s", 
+						line, count, output)
+				}
+			}
+		})
+	}
+}

--- a/pkg/tui/renderer.go
+++ b/pkg/tui/renderer.go
@@ -39,18 +39,20 @@ func (r *TreeRenderer) renderChildren(children []*tree.Node, prefix string) erro
 	for i, child := range children {
 		isLast := i == len(children)-1
 		
-		// Determine the connector and next prefix
-		var connector, nextPrefix string
+		// Determine the connector and continuation prefix for multi-line content
+		var connector, continuationPrefix, nextPrefix string
 		if isLast {
 			connector = "└── "
+			continuationPrefix = prefix + "    " // No more siblings, use spaces
 			nextPrefix = prefix + "    "
 		} else {
 			connector = "├── "
+			continuationPrefix = prefix + "│   " // Has siblings, maintain connector
 			nextPrefix = prefix + "│   "
 		}
 		
-		// Render the current node
-		if err := r.renderNode(child, prefix+connector); err != nil {
+		// Render the current node with proper prefixes
+		if err := r.renderNodeWithPrefix(child, prefix, connector, continuationPrefix); err != nil {
 			return err
 		}
 		
@@ -65,17 +67,17 @@ func (r *TreeRenderer) renderChildren(children []*tree.Node, prefix string) erro
 	return nil
 }
 
-// renderNode renders a single node with its annotation
-func (r *TreeRenderer) renderNode(node *tree.Node, prefix string) error {
-	// Start with the prefix and node name
-	line := prefix + node.Name
+
+// renderNodeWithPrefix renders a single node with proper prefix handling for multi-line content
+func (r *TreeRenderer) renderNodeWithPrefix(node *tree.Node, treePrefix, connector, continuationPrefix string) error {
+	// Start with the full prefix (tree prefix + connector) and node name
+	line := treePrefix + connector + node.Name
 	
 	// Add annotation if present and enabled
 	if r.showAnnotations && node.Annotation != nil {
 		annotation := r.formatAnnotation(node.Annotation)
 		if annotation != "" {
 			// Calculate padding to align annotations
-			// We'll use a simple approach: add some spaces and then the annotation
 			padding := r.calculatePadding(len(line))
 			line += padding + annotation
 		}
@@ -88,7 +90,15 @@ func (r *TreeRenderer) renderNode(node *tree.Node, prefix string) error {
 	
 	// If we have a multi-line annotation, render the additional lines
 	if r.showAnnotations && node.Annotation != nil {
-		additionalLines := r.getAdditionalAnnotationLines(node.Annotation, prefix)
+		// For multi-line content, we need to use the continuation prefix
+		// which maintains the tree structure without the connector
+		multiLinePrefix := continuationPrefix
+		if continuationPrefix == "" {
+			// Fallback for backward compatibility
+			multiLinePrefix = treePrefix + strings.Repeat(" ", len(connector))
+		}
+		
+		additionalLines := r.getAdditionalAnnotationLines(node.Annotation, multiLinePrefix)
 		for _, additionalLine := range additionalLines {
 			if _, err := fmt.Fprintf(r.writer, "%s\n", additionalLine); err != nil {
 				return err
@@ -157,23 +167,19 @@ func (r *TreeRenderer) getAdditionalAnnotationLines(annotation *info.Annotation,
 
 // createAnnotationIndent creates proper indentation for annotation continuation lines
 func (r *TreeRenderer) createAnnotationIndent(prefix string) string {
-	// Replace tree characters with spaces to maintain alignment
-	indent := ""
-	for _, char := range prefix {
-		switch char {
-		case '├', '└':
-			indent += " "
-		case '─':
-			indent += " "
-		case '│':
-			indent += "│"
-		default:
-			indent += string(char)
-		}
+	// The prefix already contains the proper tree structure
+	// We need to maintain it and add padding to reach the annotation column
+	
+	// Just return the prefix with padding to reach the target column
+	// The prefix should already have the tree connectors (│) we need
+	targetColumn := 40
+	currentLen := len(prefix)
+	
+	if currentLen >= targetColumn {
+		return prefix + "  " // Minimum spacing if we're already past the target
 	}
 	
-	// Add some extra spaces to align with the annotation text
-	return indent + strings.Repeat(" ", 20) // Adjust this value as needed
+	return prefix + strings.Repeat(" ", targetColumn-currentLen)
 }
 
 // calculatePadding calculates padding to align annotations

--- a/pkg/tui/renderer.go
+++ b/pkg/tui/renderer.go
@@ -132,7 +132,13 @@ func (r *TreeRenderer) getAdditionalAnnotationLines(annotation *info.Annotation,
 	// If we used the first line of description, show the remaining lines
 	startIndex := 1
 	if annotation.Title != "" {
-		startIndex = 0 // Show all description lines if we used title
+		// Skip the first line of description if it's the same as the title
+		// (which is common when the parser includes the title in the description)
+		if len(lines) > 0 && strings.TrimSpace(lines[0]) == annotation.Title {
+			startIndex = 1
+		} else {
+			startIndex = 0
+		}
 	}
 	
 	// Create the indentation for additional lines

--- a/pkg/tui/styled_renderer.go
+++ b/pkg/tui/styled_renderer.go
@@ -229,7 +229,16 @@ func (r *StyledTreeRenderer) renderChildren(children []*tree.Node, prefix string
 		styledConnector := r.styles.TreeLines.Render(connector)
 		
 		// Render the current node
-		if err := r.renderNode(child, prefix+styledConnector, nextPrefix); err != nil {
+		// Pass the continuation prefix for multi-line content (prefix without the connector)
+		var continuationPrefix string
+		if !isLast {
+			// For non-last children, add the vertical line
+			continuationPrefix = prefix + r.styles.TreeLines.Render("│   ")
+		} else {
+			// For last children, add spaces
+			continuationPrefix = prefix + "    "
+		}
+		if err := r.renderNode(child, prefix+styledConnector, continuationPrefix); err != nil {
 			return err
 		}
 		
@@ -245,7 +254,7 @@ func (r *StyledTreeRenderer) renderChildren(children []*tree.Node, prefix string
 }
 
 // renderNode renders a single node with its annotation using beautiful styling
-func (r *StyledTreeRenderer) renderNode(node *tree.Node, prefix, nextPrefix string) error {
+func (r *StyledTreeRenderer) renderNode(node *tree.Node, prefix, continuationPrefix string) error {
 	// Style the node name based on whether it has annotations
 	var styledName string
 	if node.Annotation != nil {
@@ -284,7 +293,8 @@ func (r *StyledTreeRenderer) renderNode(node *tree.Node, prefix, nextPrefix stri
 	
 	// Render multi-line annotation if present
 	if r.showAnnotations && node.Annotation != nil {
-		if err := r.renderMultiLineAnnotation(node.Annotation, nextPrefix); err != nil {
+		// Use the continuation prefix that was passed in
+		if err := r.renderMultiLineAnnotation(node.Annotation, continuationPrefix); err != nil {
 			return err
 		}
 	}
@@ -364,18 +374,25 @@ func (r *StyledTreeRenderer) renderMultiLineAnnotation(annotation *info.Annotati
 		// Style the content with annotation text styling
 		styledContent := r.styles.AnnotationText.Render(annotationContent)
 		
-		// Create tabstop-aligned indentation
-		tabstopIndent := strings.Repeat(" ", r.tabstop)
+		// Create proper indentation that maintains tree structure
+		// The basePrefix already contains the tree connectors (│) we need
+		// We need to add spacing to align with the annotation column
+		treeIndent := basePrefix
+		// Add spacing to reach the tabstop position
+		spacingNeeded := r.tabstop - r.safeWidth(basePrefix)
+		if spacingNeeded > 0 {
+			treeIndent += strings.Repeat(" ", spacingNeeded)
+		}
 		
 		// Apply container styling
 		containerStyle := r.styles.AnnotationContainer
 		
-		// Split into lines and render each with tabstop alignment
+		// Split into lines and render each with proper tree-aware indentation
 		contentLines := strings.Split(styledContent, "\n")
 		for _, line := range contentLines {
 			if strings.TrimSpace(line) != "" {
 				styledLine := containerStyle.Render(line)
-				if _, err := fmt.Fprintf(r.writer, "%s%s\n", tabstopIndent, styledLine); err != nil {
+				if _, err := fmt.Fprintf(r.writer, "%s%s\n", treeIndent, styledLine); err != nil {
 					return err
 				}
 			}

--- a/pkg/tui/styled_renderer.go
+++ b/pkg/tui/styled_renderer.go
@@ -332,10 +332,16 @@ func (r *StyledTreeRenderer) renderMultiLineAnnotation(annotation *info.Annotati
 			// since the content is already displayed inline
 			startIndex = len(lines) // This will skip all lines
 		} else {
-			// If we used the title as inline annotation, show all description lines
-			startIndex = 0
+			// If we used the title as inline annotation, we need to skip
+			// the first line of the description if it's the same as the title
+			// (which is common when the parser includes the title in the description)
+			if len(lines) > 0 && strings.TrimSpace(lines[0]) == annotation.Title {
+				startIndex = 1
+			} else {
+				startIndex = 0
+			}
 			
-			// But skip empty first lines
+			// Skip empty lines at the beginning
 			for startIndex < len(lines) && strings.TrimSpace(lines[startIndex]) == "" {
 				startIndex++
 			}

--- a/pkg/tui/styles.go
+++ b/pkg/tui/styles.go
@@ -62,12 +62,7 @@ func NewTreeStyles() *TreeStyles {
 			Bold(true),
 		
 		AnnotationContainer: lipgloss.NewStyle().
-			PaddingLeft(2).
-			BorderLeft(true).
-			BorderStyle(lipgloss.Border{
-				Left: "│",
-			}).
-			BorderForeground(AnnotationBorderColor),
+			PaddingLeft(1), // Just a small padding, no border since we maintain tree structure
 		
 		// Layout styles
 		AnnotationSeparator: lipgloss.NewStyle().


### PR DESCRIPTION
## Summary
- Fixed duplicate title display when annotations have both title and description
- Fixed tree connector alignment for multi-line annotations
- Removed extra border from styled renderer that was adding duplicate connectors

## Changes
1. **Plain Renderer**: Updated to use continuation prefix for proper tree structure in multi-line content
2. **Styled Renderer**: Modified to pass correct continuation prefix and maintain tree connectors
3. **Styles**: Removed the extra border from `AnnotationContainer` that was causing duplicate │ characters
4. **Tests**: Added comprehensive tests for connector alignment in both plain and styled renderers

## Test plan
- [x] Added unit tests for connector alignment (`pkg/tui/connector_alignment_test.go`)
- [x] Added tests for duplicate title bug (`pkg/tui/duplicate_title_test.go`)
- [x] All existing tests pass
- [x] Manual testing with various tree structures

🤖 Generated with [Claude Code](https://claude.ai/code)