### PR TITLE
feat: Improve visual UI for tree rendering

### DIFF
--- a/cmd/treex/commands/show.go
+++ b/cmd/treex/commands/show.go
@@ -82,7 +82,7 @@ func init() {
 	showCmd.Flags().StringVar(&ignoreFile, "use-ignore-file", ".gitignore", "Use specified ignore file (default is .gitignore)")
 	showCmd.Flags().IntVarP(&maxDepth, "depth", "d", 10, "Maximum depth to traverse")
 	showCmd.Flags().BoolVar(&safeMode, "safe-mode", false, "Force safe terminal rendering mode (useful for terminals with rendering issues)")
-	showCmd.Flags().BoolVar(&extraSpacing, "extra-spacing", true, "Add extra vertical spacing between annotated items")
+	showCmd.Flags().BoolVar(&extraSpacing, "extra-spacing", false, "Add extra vertical spacing between annotated items")
 
 	// Register the command with root
 	rootCmd.AddCommand(showCmd)

--- a/pkg/display/styles/styles.go
+++ b/pkg/display/styles/styles.go
@@ -85,14 +85,14 @@ func NewTreeStyles() *TreeStyles {
 			Foreground(Colors.TreeDirectory).
 			Bold(true),
 		
-		AnnotatedPath: base.Text,  // Items with info use regular text
+		AnnotatedPath: base.TextBold,  // Items with info use bold text
 		
-		UnannotatedPath: base.TextFaint,  // Items without info use faint text
+		UnannotatedPath: base.TextFaint.Bold(true),  // Items without info use faint bold text
 		
 		// Annotation styles - compose from base styles
-		AnnotationText: base.TextTitle,  // Use title style for inline annotations
+		AnnotationText: base.Text,  // Use regular text for inline annotations
 		
-		AnnotationNotes: base.TextTitle,  // Use title style (bold) for notes
+		AnnotationNotes: base.Text,  // Use regular text for notes
 		
 		AnnotationDescription: base.TextSubtle,  // Use subtle for descriptions
 		
@@ -136,12 +136,12 @@ func NewMinimalTreeStyles() *TreeStyles {
 		// Tree structure styles - using minimal base styles
 		TreeLines:       base.Structure,
 		RootPath:        base.TextBold,
-		AnnotatedPath:   base.Text,
-		UnannotatedPath: base.Structure,
+		AnnotatedPath:   base.TextBold,
+		UnannotatedPath: base.Structure.Bold(true),
 		
 		// Annotation styles
-		AnnotationText:        base.TextTitle,
-		AnnotationNotes:       base.TextTitle,
+		AnnotationText:        base.Text,
+		AnnotationNotes:       base.Text,
 		AnnotationDescription: base.Text,
 		AnnotationContainer:   base.Text,
 		
@@ -179,12 +179,12 @@ func NewNoColorTreeStyles() *TreeStyles {
 		// Tree structure styles - using no-color base styles
 		TreeLines:       base.Structure,
 		RootPath:        base.TextBold,
-		AnnotatedPath:   base.Text,
-		UnannotatedPath: base.Structure,
+		AnnotatedPath:   base.TextBold,
+		UnannotatedPath: base.Structure.Bold(true),
 		
 		// Annotation styles
-		AnnotationText:        base.TextBold,
-		AnnotationNotes:       base.TextBold,
+		AnnotationText:        base.Text,
+		AnnotationNotes:       base.Text,
 		AnnotationDescription: base.Text,
 		AnnotationContainer:   base.Text,
 		


### PR DESCRIPTION
## Summary
This PR improves the visual UI of the tree rendering by making two key changes:

1. **Removed extra spacing between annotated items by default** - The tree output is now more compact
2. **Made file/directory names bold while annotations are regular text** - This creates better visual hierarchy

## Changes
- Changed default value of `--extra-spacing` flag from `true` to `false`
- Updated styles to make `AnnotatedPath` and `UnannotatedPath` use bold text
- Changed annotation text (`AnnotationText`, `AnnotationNotes`) to regular weight
- Applied changes consistently across all three themes: color, minimal, and no-color

## Before/After

**Before:**
```
treex
├── cmd
│   └── treex
│       ├── commands
│       │   ├── templates               Template files
│       │   │   
│       │   ├── add_info.go             Add command for .info files
│       │   │   
│       │   ├── check.go                Validate .info files
```

**After:**
```
treex
├── cmd
│   └── treex
│       ├── commands
│       │   ├── templates               Template files
│       │   ├── add_info.go             Add command for .info files
│       │   ├── check.go                Validate .info files
```

In the actual terminal, file names are now **bold** while annotations remain regular text.

## Notes
- The `--extra-spacing` flag can still be used to restore the previous behavior with extra lines
- All tests pass
- This provides cleaner, more readable output that emphasizes the file structure

🤖 Generated with [Claude Code](https://claude.ai/code)