### PR TITLE
feat: Support whitespace-separated format in .info files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ In locus documentation that's easy to write , explore and extend:
 ```bash
 # annotate your source tree in a simple plain text file
 $ cat .info # goo-ole plain text, as simple as it gets
-cmd: Command Line Utilities
-docs/guides: User guides and tutorials
+cmd Command Line Utilities
+docs/guides User guides and tutorials
 
 $ treex 
     my-project
@@ -18,15 +18,16 @@ $ treex
 
 These are very useful for documentation and exploration but are time consuming to generate, will out sync actual file structure and are not available when you most use it: in the shell when working on the codebase.
 
-treex reads .info files, plain text files in the format <path>:<annotation> and generates annotated trees, right in you shell as you work. .info files can be source controlled and kept next to the files they document, keeping thing local and in syn.
+treex reads .info files, plain text files in the format <path> <annotation> and generates annotated trees, right in you shell as you work. .info files can be source controlled and kept next to the files they document, keeping thing local and in syn.
 
 ## Quick Start
 
 treex will render .info files, plain text such as :
 
 ```text
-   <path>:<annotation>
-   src/main.py: The entry point for the application
+   src/main.py The entry point for the application
+   docs/README.md Project documentation
+   cmd/app Main application executable
 ```
 
 It also has convenience tools for easier documentation:
@@ -52,10 +53,16 @@ You can render markdown or html for your docs
 
 ## Info Files
 
-treex uses `.info` files :
+treex uses `.info` files with a simple format:
 
 ```text
-<path>: <description>
+<path> <description>
+```
+
+For paths containing spaces, use the colon format:
+
+```text
+<path with spaces>: <description>
 ```
 
 These files can be distributed throughout your project, keeping documentation close to the code it describes. treex recursively finds and combines them when rendering your project map.
@@ -70,7 +77,7 @@ Render your project map. Works from any directory in your project.
 
 Create a new `.info` file with the specified paths, ready for you to annotate.
 
-### `treex add <path>: <description>`
+### `treex add <path> <description>`
 
 Add or update an annotation for a specific path.
 

--- a/cmd/treex/commands/show_warnings_test.go
+++ b/cmd/treex/commands/show_warnings_test.go
@@ -38,7 +38,7 @@ func TestShowCommandWithWarnings(t *testing.T) {
 	infoContent := `README.md: Project documentation
 src/main.go: Entry point
 src/deleted.go: This file doesn't exist
-Invalid line without colon
+Invalid
 : Empty path
 test/: Empty notes`
 	
@@ -94,7 +94,7 @@ test/: Empty notes`
 	}
 	
 	// Check for specific warnings
-	if !strings.Contains(outputStr, "Invalid format (missing colon)") {
+	if !strings.Contains(outputStr, "Invalid format (missing annotation)") {
 		t.Error("Expected invalid format warning")
 	}
 	if !strings.Contains(outputStr, "Path not found") && !strings.Contains(outputStr, "src/deleted.go") {

--- a/pkg/core/info/parser.go
+++ b/pkg/core/info/parser.go
@@ -65,17 +65,33 @@ func (p *Parser) ParseFileWithWarnings(infoFilePath string) (map[string]*types.A
 			continue
 		}
 
-		// Find the colon separator
+		// Try to parse the line - first check for colon format
 		colonIdx := strings.Index(line, ":")
-		if colonIdx == -1 {
-			// Add warning for lines without colon separator
-			warnings = append(warnings, fmt.Sprintf("Line %d: Invalid format (missing colon): %q", lineNum+1, line))
-			continue
+		var path, notes string
+		
+		if colonIdx != -1 {
+			// Colon format: path:annotation
+			path = strings.TrimSpace(line[:colonIdx])
+			notes = strings.TrimSpace(line[colonIdx+1:])
+		} else {
+			// No colon - try whitespace format
+			// Split by first whitespace (space or tab), first part is path, rest is annotation
+			// Use Fields to properly handle tabs and multiple spaces
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				// Add warning for lines without annotation
+				warnings = append(warnings, fmt.Sprintf("Line %d: Invalid format (missing annotation): %q", lineNum+1, line))
+				continue
+			}
+			
+			// First field is the path
+			path = fields[0]
+			
+			// Find where the path ends in the original line to preserve spacing in annotation
+			pathEnd := strings.Index(line, path) + len(path)
+			// Everything after the path (and its trailing whitespace) is the annotation
+			notes = strings.TrimSpace(line[pathEnd:])
 		}
-
-		// Parse format (path:notes)
-		path := strings.TrimSpace(line[:colonIdx])
-		notes := strings.TrimSpace(line[colonIdx+1:])
 		
 		if path == "" {
 			// Warn about empty path

--- a/pkg/core/info/parser_format_test.go
+++ b/pkg/core/info/parser_format_test.go
@@ -1,0 +1,212 @@
+package info
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseFileFormats(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantPaths   map[string]string // path -> expected annotation
+		wantWarnings int
+	}{
+		{
+			name: "whitespace format - simple",
+			content: `README.md Project documentation
+main.go Main entry point
+src/app.go Application logic`,
+			wantPaths: map[string]string{
+				"README.md":  "Project documentation",
+				"main.go":    "Main entry point",
+				"src/app.go": "Application logic",
+			},
+			wantWarnings: 0,
+		},
+		{
+			name: "whitespace format - multiple words in annotation",
+			content: `README.md This is the main project documentation file
+src/app.go Core application logic with business rules
+test.txt A simple test file for testing purposes`,
+			wantPaths: map[string]string{
+				"README.md":  "This is the main project documentation file",
+				"src/app.go": "Core application logic with business rules",
+				"test.txt":   "A simple test file for testing purposes",
+			},
+			wantWarnings: 0,
+		},
+		{
+			name: "colon format - for paths with spaces",
+			content: `path with spaces/file.txt: This file has spaces in path
+normal/path.go: Regular path with colon
+another path/doc.md: Another file with spaces`,
+			wantPaths: map[string]string{
+				"path with spaces/file.txt": "This file has spaces in path",
+				"normal/path.go":            "Regular path with colon",
+				"another path/doc.md":       "Another file with spaces",
+			},
+			wantWarnings: 0,
+		},
+		{
+			name: "mixed formats",
+			content: `README.md Simple whitespace format
+path with spaces/file.txt: Colon format for spaces
+src/main.go Main application entry point
+config/app settings.yaml: Configuration file with spaces
+test.go Unit tests`,
+			wantPaths: map[string]string{
+				"README.md":                "Simple whitespace format",
+				"path with spaces/file.txt": "Colon format for spaces",
+				"src/main.go":              "Main application entry point",
+				"config/app settings.yaml": "Configuration file with spaces",
+				"test.go":                  "Unit tests",
+			},
+			wantWarnings: 0,
+		},
+		{
+			name: "whitespace format with tabs",
+			content: "file1.txt\tAnnotation with tab separator\nfile2.go\t\tMultiple tabs before annotation",
+			wantPaths: map[string]string{
+				"file1.txt": "Annotation with tab separator",
+				"file2.go":  "Multiple tabs before annotation",
+			},
+			wantWarnings: 0,
+		},
+		{
+			name: "edge cases - empty lines and missing annotations",
+			content: `
+valid.txt This is valid
+
+missing_annotation
+
+another.go Valid annotation
+`,
+			wantPaths: map[string]string{
+				"valid.txt":  "This is valid",
+				"another.go": "Valid annotation",
+			},
+			wantWarnings: 1, // missing_annotation line
+		},
+		{
+			name: "colon format handles colons in annotation",
+			content: `file.txt: This has: multiple colons in annotation
+path/to/file.txt: URL in annotation: https://example.com`,
+			wantPaths: map[string]string{
+				"file.txt":        "This has: multiple colons in annotation",
+				"path/to/file.txt": "URL in annotation: https://example.com",
+			},
+			wantWarnings: 0,
+		},
+		{
+			name: "whitespace in annotations preserved",
+			content: `file1.txt    Annotation   with   extra   spaces
+file2.go Annotation with     trailing spaces    `,
+			wantPaths: map[string]string{
+				"file1.txt": "Annotation   with   extra   spaces",
+				"file2.go":  "Annotation with     trailing spaces",
+			},
+			wantWarnings: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directory and .info file
+			tempDir := t.TempDir()
+			infoPath := filepath.Join(tempDir, ".info")
+			
+			err := os.WriteFile(infoPath, []byte(tt.content), 0644)
+			if err != nil {
+				t.Fatalf("Failed to create test .info file: %v", err)
+			}
+
+			// Parse the file
+			parser := NewParser()
+			annotations, warnings, err := parser.ParseFileWithWarnings(infoPath)
+			if err != nil {
+				t.Fatalf("ParseFileWithWarnings failed: %v", err)
+			}
+
+			// Check warnings count
+			if len(warnings) != tt.wantWarnings {
+				t.Errorf("Expected %d warnings, got %d: %v", tt.wantWarnings, len(warnings), warnings)
+			}
+
+			// Check annotations
+			if len(annotations) != len(tt.wantPaths) {
+				t.Errorf("Expected %d annotations, got %d", len(tt.wantPaths), len(annotations))
+			}
+
+			for path, wantNotes := range tt.wantPaths {
+				ann, exists := annotations[path]
+				if !exists {
+					t.Errorf("Missing annotation for path %q", path)
+					continue
+				}
+				if ann.Notes != wantNotes {
+					t.Errorf("Path %q: expected notes %q, got %q", path, wantNotes, ann.Notes)
+				}
+			}
+
+			// Check for unexpected annotations
+			for path := range annotations {
+				if _, expected := tt.wantPaths[path]; !expected {
+					t.Errorf("Unexpected annotation for path %q", path)
+				}
+			}
+		})
+	}
+}
+
+// Test backward compatibility with existing .info files
+func TestParseFileBackwardCompatibility(t *testing.T) {
+	// Test that old colon-only format still works
+	oldFormatContent := `src/main.go: Application entry point
+pkg/parser.go: Parser implementation
+test/test.go: Unit tests
+docs/readme.md: Documentation`
+
+	tempDir := t.TempDir()
+	infoPath := filepath.Join(tempDir, ".info")
+	
+	err := os.WriteFile(infoPath, []byte(oldFormatContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test .info file: %v", err)
+	}
+
+	parser := NewParser()
+	annotations, warnings, err := parser.ParseFileWithWarnings(infoPath)
+	if err != nil {
+		t.Fatalf("ParseFileWithWarnings failed: %v", err)
+	}
+
+	if len(warnings) > 0 {
+		t.Errorf("Old format should not produce warnings: %v", warnings)
+	}
+
+	expectedCount := 4
+	if len(annotations) != expectedCount {
+		t.Errorf("Expected %d annotations, got %d", expectedCount, len(annotations))
+	}
+
+	// Verify all old format entries are parsed correctly
+	expectedAnnotations := map[string]string{
+		"src/main.go":   "Application entry point",
+		"pkg/parser.go": "Parser implementation",
+		"test/test.go":  "Unit tests",
+		"docs/readme.md": "Documentation",
+	}
+
+	for path, wantNotes := range expectedAnnotations {
+		ann, exists := annotations[path]
+		if !exists {
+			t.Errorf("Missing annotation for path %q", path)
+			continue
+		}
+		if ann.Notes != wantNotes {
+			t.Errorf("Path %q: expected notes %q, got %q", path, wantNotes, ann.Notes)
+		}
+	}
+}

--- a/pkg/core/info/parser_warnings_test.go
+++ b/pkg/core/info/parser_warnings_test.go
@@ -25,8 +25,8 @@ docs/api.md
 src/main.go: Another valid annotation
 docs/guide.md`,
 			expectedWarnings: []string{
-				"Line 2: Invalid format (missing colon): \"docs/api.md\"",
-				"Line 4: Invalid format (missing colon): \"docs/guide.md\"",
+				"Line 2: Invalid format (missing annotation): \"docs/api.md\"",
+				"Line 4: Invalid format (missing annotation): \"docs/guide.md\"",
 			},
 			expectedAnnotations: map[string]string{
 				"README.md": "Valid annotation",
@@ -52,13 +52,13 @@ src/utils.go:
 		{
 			name: "mixed valid and invalid lines",
 			infoContent: `src/main.go: Entry point
-This is not a valid line
+This
 test/test.go: Unit tests
 src/deleted.go: File that was removed
-Another invalid line without colon`,
+Another`,
 			expectedWarnings: []string{
-				"Line 2: Invalid format (missing colon): \"This is not a valid line\"",
-				"Line 5: Invalid format (missing colon): \"Another invalid line without colon\"",
+				"Line 2: Invalid format (missing annotation): \"This\"",
+				"Line 5: Invalid format (missing annotation): \"Another\"",
 			},
 			expectedAnnotations: map[string]string{
 				"src/main.go": "Entry point",
@@ -140,7 +140,7 @@ func TestParseDirectoryTreeWithWarnings(t *testing.T) {
 	rootInfo := `README.md: Project documentation
 src/main.go: Entry point
 src/deleted.go: This file doesn't exist
-Invalid line without colon`
+Invalid`
 	
 	err = os.WriteFile(filepath.Join(tempDir, ".info"), []byte(rootInfo), 0644)
 	if err != nil {
@@ -190,7 +190,7 @@ helper.go: Helper functions
 	hasEmptyPathWarning := false
 	
 	for _, w := range warnings {
-		if strings.Contains(w, "Invalid format (missing colon)") {
+		if strings.Contains(w, "Invalid format (missing annotation)") {
 			hasInvalidFormatWarning = true
 		}
 		if strings.Contains(w, "Path not found") && strings.Contains(w, "src/deleted.go") {


### PR DESCRIPTION
## Summary
- Add support for whitespace-separated format in .info files for easier authoring
- Maintain backward compatibility with existing colon format
- Update documentation to showcase the simpler format

## Changes
This PR enhances the .info file parser to support both formats:

1. **Whitespace format** (new, simpler):
   ```
   src/main.go Main application entry point
   README.md Project documentation
   ```

2. **Colon format** (existing, for paths with spaces):
   ```
   path with spaces/file.txt: File in directory with spaces
   docs/My Documents/guide.md: User guide
   ```

### Implementation Details
- Modified `pkg/core/info/parser.go` to check for colon first, then fall back to whitespace separation
- Added comprehensive test suite in `pkg/core/info/parser_format_test.go`
- Updated existing tests to match new parser behavior
- Updated README.md to demonstrate the simpler whitespace format

## Test plan
- [x] Run existing test suite - all tests pass
- [x] Add new tests for whitespace format parsing
- [x] Add tests for tab-separated formats
- [x] Test mixed format files (both colon and whitespace in same file)
- [x] Test edge cases (empty lines, missing annotations, etc.)
- [x] Verify backward compatibility with existing .info files
- [x] Manual testing with `treex show` command

🤖 Generated with [Claude Code](https://claude.ai/code)