### PR TITLE
[Experimental] Reorganize CLI with info- prefix for annotation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ to export to markdown though `.info` files: dead simple plain files co-located w
 # annotate your source tree in a simple plain text file
 $ echo "cmd/ Command Line Utilities" >> .info
 # or use treex helpers
-$ treex add docs/guides "In-depth guides for development"
+$ treex info-add docs/guides "In-depth guides for development"
 $ treex 
     my-project
     ├─ cmd/                    Command line utilities
@@ -20,7 +20,7 @@ $ treex
 # export to mardown 
 $ treex --format markdown >> README.md
 # update your .info to reflect changes in the file system 
-$ treex sync
+$ treex info-sync
 # .info file are as simple as they come: 
 $ cat .info 
 cmd/ Command line utilities
@@ -45,13 +45,13 @@ It also has convenience tools for easier documentation:
 
    ```bash
    # generates the .info with the paths specified
-   **treex** init src/core build scripts/deploy.sh
+   **treex** info-init src/core build scripts/deploy.sh
    # add an annotation for a given path
-   treex add tests/setup "Make sure this is ran before any tests"
+   treex info-add tests/setup "Make sure this is ran before any tests"
    # verify a .info file
    treex check
    # verify it it's out of sync, pruning removed paths: 
-   treex sync
+   treex info-sync
    ```
 
 You can render markdown
@@ -131,15 +131,15 @@ See the included `treex.yaml` file for a fully documented example of all availab
 
 Render your project map. Works from any directory in your project.
 
-* **`treex init <path1> <path2> ... <pathN>`**:  Create a new `.info` file with the specified paths, ready for you to annotate (use `--force` to overwrite existing file without confirmation).
-* **`treex add <path> <description>`**: Add or update an annotation for a specific path. Multi-word descriptions no longer require quotes.
-* **`treex del <path>`**: Delete the annotation for a specific path from the `.info` file (only removes the annotation, not the file itself).
-* **`treex sync`**: Delete annotations for non-existent paths from all `.info` files (use `--force` to skip confirmation).
-* **`treex search <term>`**: Search for a term in all `.info` files (searches both paths and annotations).
-* **`treex edit [path]`**: Open `.info` file(s) in your editor, optionally jumping to a specific annotation line.
+* **`treex info-init <path1> <path2> ... <pathN>`**:  Create a new `.info` file with the specified paths, ready for you to annotate (use `--force` to overwrite existing file without confirmation).
+* **`treex info-add <path> <description>`**: Add or update an annotation for a specific path. Multi-word descriptions no longer require quotes.
+* **`treex info-del <path>`**: Delete the annotation for a specific path from the `.info` file (only removes the annotation, not the file itself).
+* **`treex info-sync`**: Delete annotations for non-existent paths from all `.info` files (use `--force` to skip confirmation).
+* **`treex info-search <term>`**: Search for a term in all `.info` files (searches both paths and annotations).
+* **`treex info-edit [path]`**: Open `.info` file(s) in your editor, optionally jumping to a specific annotation line.
 * **`treex config`**: Output the default configuration file with all options documented.
 
-### `treex draw`
+### `treex info-draw`
 
 Create tree diagrams from .info format without requiring filesystem paths to exist. Perfect for documentation diagrams, organizational charts, family trees, and conceptual structures.
 
@@ -154,13 +154,13 @@ Create tree diagrams from .info format without requiring filesystem paths to exi
 
 ```bash
 # Create a simple org chart
-echo -e "CEO Alice Thompson, Chief Executive\nCTO\tDavid Kim, Chief Technology\nCTO/Engineering/\tEngineering Team" | treex draw
+echo -e "CEO Alice Thompson, Chief Executive\nCTO\tDavid Kim, Chief Technology\nCTO/Engineering/\tEngineering Team" | treex info-draw
 
 # Render from a file
-treex draw --info-file organization.info
+treex info-draw --info-file organization.info
 
 # Export to markdown for documentation
-treex draw --info-file project-plan.info --format markdown > ARCHITECTURE.md
+treex info-draw --info-file project-plan.info --format markdown > ARCHITECTURE.md
 
 # Family tree example
 cat > family.info << EOF
@@ -171,7 +171,7 @@ Parents/ Our generation
 Parents/Dad Michael, born 1980
 Parents/Mom Sarah, born 1982
 EOF
-treex draw --info-file family.info
+treex info-draw --info-file family.info
 ```
 
 #### Key Features

--- a/cmd/treex/commands/add_info.go
+++ b/cmd/treex/commands/add_info.go
@@ -13,7 +13,7 @@ import (
 var addInfoHelp string
 
 var addInfoCmd = &cobra.Command{
-	Use:     "add <path> <description>",
+	Use:     "info-add <path> <description>",
 	Short:   "Add or update an entry in the current directory's .info file",
 	GroupID: "info",
 	Long:    addInfoHelp,

--- a/cmd/treex/commands/add_info.help.txt
+++ b/cmd/treex/commands/add_info.help.txt
@@ -8,19 +8,19 @@ This command will:
 
 Examples:
   # Multi-word annotations without quotes (recommended)
-  treex add pkg Main package containing core functionality
-  treex add config/ Configuration files and settings
-  treex add main.go Application entry point
+  treex info-add pkg Main package containing core functionality
+  treex info-add config/ Configuration files and settings
+  treex info-add main.go Application entry point
   
   # Quoted strings still work for compatibility
-  treex add pkg "Main package containing core functionality"
-  treex add config/ "Configuration files and settings"
+  treex info-add pkg "Main package containing core functionality"
+  treex info-add config/ "Configuration files and settings"
   
   # Use --replace to overwrite existing entries
-  treex add --replace main.go Updated application entry point
+  treex info-add --replace main.go Updated application entry point
   
   # Paths with spaces need quotes
-  treex add "path with spaces/file.txt" Description of the file
+  treex info-add "path with spaces/file.txt" Description of the file
   
 NOTES:
   - All arguments after the path are joined to form the description

--- a/cmd/treex/commands/del.go
+++ b/cmd/treex/commands/del.go
@@ -12,7 +12,7 @@ import (
 )
 
 var delCmd = &cobra.Command{
-	Use:   "del <path>",
+	Use:   "info-del <path>",
 	Short: "Delete annotation for a path from .info file",
 	Long:  "Delete the annotation for a specific path from the .info file without affecting the actual file or directory",
 	Args:  cobra.ExactArgs(1),

--- a/cmd/treex/commands/del_test.go
+++ b/cmd/treex/commands/del_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// setupDelCmd creates a properly initialized test del command
+// setupDelCmd creates a properly initialized test info-del command
 func setupDelCmd() *cobra.Command {
 	// Reset infoFile to default
 	infoFile = ".info"
@@ -23,19 +23,19 @@ func setupDelCmd() *cobra.Command {
 		},
 	}
 
-	// Add the del command
+	// Add the info-del command
 	testRootCmd.AddCommand(delCmd)
 
 	return testRootCmd
 }
 
-// executeDelCommand is a helper function to execute the del command
+// executeDelCommand is a helper function to execute the info-del command
 func executeDelCommand(args ...string) (output string, err error) {
 	root := setupDelCmd()
 	buf := new(bytes.Buffer)
 	root.SetOut(buf)
 	root.SetErr(buf)
-	root.SetArgs(append([]string{"del"}, args...))
+	root.SetArgs(append([]string{"info-del"}, args...))
 
 	_, err = root.ExecuteC()
 	return buf.String(), err

--- a/cmd/treex/commands/draw.go
+++ b/cmd/treex/commands/draw.go
@@ -20,7 +20,7 @@ var drawHelp string
 
 // drawCmd represents the draw command
 var drawCmd = &cobra.Command{
-	Use:     "draw [--info-file FILE | -]",
+	Use:     "info-draw [--info-file FILE | -]",
 	Short:   "Draw tree diagrams from info files without filesystem validation",
 	Long:    drawHelp,
 	GroupID: "info",

--- a/cmd/treex/commands/draw.help.txt
+++ b/cmd/treex/commands/draw.help.txt
@@ -13,22 +13,22 @@ WHEN TO USE:
   - Prototyping directory structures
 
 USAGE:
-  treex draw [--info-file FILE]
-  treex draw < input.info             # Read from stdin
-  cat data.info | treex draw          # Read from pipe
+  treex info-draw [--info-file FILE]
+  treex info-draw < input.info             # Read from stdin
+  cat data.info | treex info-draw          # Read from pipe
 
 EXAMPLES:
   # Draw a family tree from file
-  treex draw --info-file family.info
+  treex info-draw --info-file family.info
   
   # Draw from stdin
-  echo -e "Dad\tChill, dad\nMom\tListen to your mother\nkids/Sam\tLittle Sam" | treex draw
+  echo -e "Dad\tChill, dad\nMom\tListen to your mother\nkids/Sam\tLittle Sam" | treex info-draw
   
   # Draw with markdown output
-  treex draw --info-file org-chart.info --format markdown
+  treex info-draw --info-file org-chart.info --format markdown
   
   # Draw from stdin with no-color format
-  cat family.info | treex draw --format no-color
+  cat family.info | treex info-draw --format no-color
 
   # Create an organization chart
   cat > org.info << EOF
@@ -40,7 +40,7 @@ EXAMPLES:
   CEO/CFO Jane Doe, Chief Financial Officer
   CEO/CFO/Accounting/ Accounting department
   EOF
-  treex draw --info-file org.info
+  treex info-draw --info-file org.info
 
   # Plan a project structure
   cat > project-plan.info << EOF
@@ -51,7 +51,7 @@ EXAMPLES:
   myapp/tests/ Test files
   myapp/docs/ Documentation
   EOF
-  treex draw --info-file project-plan.info --format markdown > PROJECT_STRUCTURE.md
+  treex info-draw --info-file project-plan.info --format markdown > PROJECT_STRUCTURE.md
 
 INFO FILE FORMAT:
 The info file uses the same format as regular treex info files:

--- a/cmd/treex/commands/edit.go
+++ b/cmd/treex/commands/edit.go
@@ -21,7 +21,7 @@ var (
 )
 
 var editCmd = &cobra.Command{
-	Use:   "edit [path]",
+	Use:   "info-edit [path]",
 	Short: "Open .info file(s) in editor at specific annotation line",
 	Long:  editHelp,
 	Args:  cobra.MaximumNArgs(1),

--- a/cmd/treex/commands/edit.help.txt
+++ b/cmd/treex/commands/edit.help.txt
@@ -5,25 +5,25 @@ for entries. When a path is provided, it finds the annotation and opens the edit
 at the exact line.
 
 USAGE:
-  treex edit                    # Open the .info file in editor
-  treex edit <path>             # Open .info file at the line containing <path>
-  treex edit --all <path>       # Open all .info files containing <path>
+  treex info-edit                    # Open the .info file in editor
+  treex info-edit <path>             # Open .info file at the line containing <path>
+  treex info-edit --all <path>       # Open all .info files containing <path>
 
 EXAMPLES:
   # Edit the main .info file
-  treex edit
+  treex info-edit
 
   # Jump to annotation for src/main.go
-  treex edit src/main.go
+  treex info-edit src/main.go
 
   # Edit all .info files that contain docs/
-  treex edit --all docs/
+  treex info-edit --all docs/
 
   # Use custom info file name
-  treex edit --info-file project.info src/main.go
+  treex info-edit --info-file project.info src/main.go
 
   # Wait for editor to close (useful for GUI editors)
-  treex edit --wait src/main.go
+  treex info-edit --wait src/main.go
 
 EDITOR DETECTION:
 The command uses the following priority to find an editor:

--- a/cmd/treex/commands/firstuse.template.txt
+++ b/cmd/treex/commands/firstuse.template.txt
@@ -10,12 +10,12 @@ HOW IT WORKS:
 
   Also, you can use treex to add annotations:
 
-    $ treex add {{.ExamplePath}} "{{.ExampleAnnotation}}"
+    $ treex info-add {{.ExamplePath}} "{{.ExampleAnnotation}}"
     $ treex
 {{.RenderedTree}}
 
 LEARN MORE:
 
   treex help               # Show all available commands
-  treex init              # Initialize a {{.InfoFileName}} file with detected project structure
+  treex info-init              # Initialize a {{.InfoFileName}} file with detected project structure
   treex help info         # Learn about {{.InfoFileName}} file format and features

--- a/cmd/treex/commands/gen_info.go
+++ b/cmd/treex/commands/gen_info.go
@@ -13,7 +13,7 @@ import (
 var genInfoHelp string
 
 var importCmd = &cobra.Command{
-	Use:     "import [file]",
+	Use:     "info-import [file]",
 	Short:   "Generate .info files from annotated tree structure",
 	GroupID: "info",
 	Long:    genInfoHelp,

--- a/cmd/treex/commands/gen_info.help.txt
+++ b/cmd/treex/commands/gen_info.help.txt
@@ -23,7 +23,7 @@ Both formats work equally well. This will generate appropriate .info files
 in the corresponding directories.
 
 Examples:
-  treex import structure.txt           # Read from file
-  treex import                         # Read from stdin
-  treex import -                       # Read from stdin (explicit)
-  echo "project/src Code" | treex import  # Pipe content
+  treex info-import structure.txt           # Read from file
+  treex info-import                         # Read from stdin
+  treex info-import -                       # Read from stdin (explicit)
+  echo "project/src Code" | treex info-import  # Pipe content

--- a/cmd/treex/commands/ignore_warnings_test.go
+++ b/cmd/treex/commands/ignore_warnings_test.go
@@ -73,35 +73,35 @@ nonexistent/path.txt Another missing file`
 
 	testRootCmd2.SetOut(output)
 	testRootCmd2.SetErr(output)
-	testRootCmd2.SetArgs([]string{"show", tempDir, "--format=no-color", "--ignore-warnings"})
+	testRootCmd2.SetArgs([]string{"show", tempDir, "--format=no-color", "--info-ignore-warnings"})
 
 	err = testRootCmd2.Execute()
 	if err != nil {
-		t.Fatalf("Command failed with --ignore-warnings: %v", err)
+		t.Fatalf("Command failed with --info-ignore-warnings: %v", err)
 	}
 
 	outputStr = output.String()
 
 	// Check that warnings are NOT displayed
 	if strings.Contains(outputStr, "⚠️  Warnings found in .info files:") {
-		t.Error("Warning header should not be displayed with --ignore-warnings")
+		t.Error("Warning header should not be displayed with --info-ignore-warnings")
 	}
 
 	if strings.Contains(outputStr, "Path not found") {
-		t.Error("Path not found warning should not be displayed with --ignore-warnings")
+		t.Error("Path not found warning should not be displayed with --info-ignore-warnings")
 	}
 
 	// But the tree should still be displayed normally
 	if !strings.Contains(outputStr, "src/") && !strings.Contains(outputStr, "src") {
-		t.Errorf("Expected src/ directory in output even with --ignore-warnings, got: %s", outputStr)
+		t.Errorf("Expected src/ directory in output even with --info-ignore-warnings, got: %s", outputStr)
 	}
 
 	if !strings.Contains(outputStr, "main.go") {
-		t.Errorf("Expected main.go in output even with --ignore-warnings, got: %s", outputStr)
+		t.Errorf("Expected main.go in output even with --info-ignore-warnings, got: %s", outputStr)
 	}
 
 	if !strings.Contains(outputStr, "Entry point") {
-		t.Errorf("Expected annotation in output even with --ignore-warnings, got: %s", outputStr)
+		t.Errorf("Expected annotation in output even with --info-ignore-warnings, got: %s", outputStr)
 	}
 }
 
@@ -141,7 +141,7 @@ nonexistent.go Missing file`
 
 	testRootCmd.SetOut(output)
 	testRootCmd.SetErr(output)
-	testRootCmd.SetArgs([]string{"show", tempDir, "--format=no-color", "--ignore-warnings"})
+	testRootCmd.SetArgs([]string{"show", tempDir, "--format=no-color", "--info-ignore-warnings"})
 
 	err = testRootCmd.Execute()
 	if err != nil {
@@ -152,7 +152,7 @@ nonexistent.go Missing file`
 
 	// No warnings should be displayed
 	if strings.Contains(outputStr, "⚠️  Warnings") {
-		t.Error("Warnings should be suppressed with --ignore-warnings")
+		t.Error("Warnings should be suppressed with --info-ignore-warnings")
 	}
 
 	// But annotations should still work
@@ -183,8 +183,8 @@ func TestIgnoreWarningsHelp(t *testing.T) {
 	}
 	
 	helpStr := output.String()
-	if !strings.Contains(helpStr, "--ignore-warnings") {
-		t.Error("Expected --ignore-warnings flag in help output")
+	if !strings.Contains(helpStr, "--info-ignore-warnings") {
+		t.Error("Expected --info-ignore-warnings flag in help output")
 	}
 	
 	if !strings.Contains(helpStr, "Don't print warnings") {

--- a/cmd/treex/commands/info_file_custom_test.go
+++ b/cmd/treex/commands/info_file_custom_test.go
@@ -193,14 +193,14 @@ func TestCustomInfoFileCommands(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Test search command
+	// Test info-search command
 	output := &bytes.Buffer{}
 	resetGlobalFlags()
 	
-	// Create search command
+	// Create info-search command
 	testRootCmd := &cobra.Command{Use: "treex"}
 	testSearchCmd := &cobra.Command{
-		Use:  "search <term>",
+		Use:  "info-search <term>",
 		Args: cobra.ExactArgs(1),
 		RunE: runSearch,
 	}
@@ -209,19 +209,19 @@ func TestCustomInfoFileCommands(t *testing.T) {
 	
 	testRootCmd.SetOut(output)
 	testRootCmd.SetErr(output)
-	testRootCmd.SetArgs([]string{"search", "Documentation", "--info-file", "project.info"})
+	testRootCmd.SetArgs([]string{"info-search", "Documentation", "--info-file", "project.info"})
 	
 	err := testRootCmd.Execute()
 	if err != nil {
-		t.Fatalf("search failed: %v", err)
+		t.Fatalf("info-search failed: %v", err)
 	}
 	
 	outputStr := output.String()
 	if !strings.Contains(outputStr, "Found 1 matches") {
-		t.Errorf("search should find match in custom info file, got: %s", outputStr)
+		t.Errorf("info-search should find match in custom info file, got: %s", outputStr)
 	}
 
-	// Test sync command (remove docs directory to make annotation stale)
+	// Test info-sync command (remove docs directory to make annotation stale)
 	if err := os.RemoveAll("docs"); err != nil {
 		t.Fatal(err)
 	}
@@ -229,10 +229,10 @@ func TestCustomInfoFileCommands(t *testing.T) {
 	output.Reset()
 	resetGlobalFlags()
 	
-	// Create sync command
+	// Create info-sync command
 	testRootCmd2 := &cobra.Command{Use: "treex"}
 	testSyncCmd := &cobra.Command{
-		Use:  "sync",
+		Use:  "info-sync",
 		RunE: runSync,
 	}
 	testSyncCmd.Flags().BoolVar(&forceSync, "force", false, "Remove stale annotations without confirmation")
@@ -241,16 +241,16 @@ func TestCustomInfoFileCommands(t *testing.T) {
 	
 	testRootCmd2.SetOut(output)
 	testRootCmd2.SetErr(output)
-	testRootCmd2.SetArgs([]string{"sync", "--info-file", "project.info", "--force"})
+	testRootCmd2.SetArgs([]string{"info-sync", "--info-file", "project.info", "--force"})
 	
 	err = testRootCmd2.Execute()
 	if err != nil {
-		t.Fatalf("sync failed: %v", err)
+		t.Fatalf("info-sync failed: %v", err)
 	}
 
 	// Check that the custom info file was updated
 	content, _ := os.ReadFile("project.info")
 	if strings.Contains(string(content), "docs Documentation") {
-		t.Error("sync should have removed stale annotation from custom info file")
+		t.Error("info-sync should have removed stale annotation from custom info file")
 	}
 }

--- a/cmd/treex/commands/info_file_test.go
+++ b/cmd/treex/commands/info_file_test.go
@@ -37,11 +37,11 @@ docs Documentation`
 		t.Fatal(err)
 	}
 
-	// Test 1: Using del command with custom info file
+	// Test 1: Using info-del command with custom info file
 	infoFile = ".info" // Reset before command
 	_, err = executeDelCommand("--info-file", ".project-info", "src")
 	if err != nil {
-		t.Errorf("unexpected error with del command: %v", err)
+		t.Errorf("unexpected error with info-del command: %v", err)
 	}
 
 	// Verify src was deleted from custom file
@@ -50,7 +50,7 @@ docs Documentation`
 		t.Error("src annotation should have been deleted")
 	}
 
-	// Test 2: Using search command with custom info file
+	// Test 2: Using info-search command with custom info file
 	// Re-create the file
 	if err := os.WriteFile(".project-info", []byte(customInfoContent), 0644); err != nil {
 		t.Fatal(err)
@@ -60,14 +60,14 @@ docs Documentation`
 	infoFile = ".info"
 	output, err := executeSearchCommand("--info-file", ".project-info", "source")
 	if err != nil {
-		t.Errorf("unexpected error with search command: %v", err)
+		t.Errorf("unexpected error with info-search command: %v", err)
 	}
 
 	if !strings.Contains(output, "Found 1 matches for 'source'") {
 		t.Errorf("expected to find match for 'source', got: %s", output)
 	}
 
-	// Test 3: Using sync command with custom info file
+	// Test 3: Using info-sync command with custom info file
 	// Remove src directory to make annotation stale
 	if err := os.RemoveAll("src"); err != nil {
 		t.Fatal(err)
@@ -77,7 +77,7 @@ docs Documentation`
 	infoFile = ".info"
 	output, err = executeSyncCommand("--info-file", ".project-info", "--force")
 	if err != nil {
-		t.Errorf("unexpected error with sync command: %v", err)
+		t.Errorf("unexpected error with info-sync command: %v", err)
 	}
 
 	if !strings.Contains(output, "Found 1 stale annotations") {

--- a/cmd/treex/commands/info_files.go
+++ b/cmd/treex/commands/info_files.go
@@ -11,7 +11,7 @@ import (
 var infoFilesContent string
 
 var infoFilesCmd = &cobra.Command{
-	Use:     "info-files",
+	Use:     "info-help",
 	Short:   "Show information about .info file format and usage",
 	GroupID: "help",
 	Long:    `Display compact reference information about .info files and their format.`,

--- a/cmd/treex/commands/infos_collect.go
+++ b/cmd/treex/commands/infos_collect.go
@@ -15,7 +15,7 @@ var (
 
 // infosCollectCmd represents the infos-collect command
 var infosCollectCmd = &cobra.Command{
-	Use:     "infos-collect [path]",
+	Use:     "info-collect [path]",
 	GroupID: "info",
 	Short:   "Collect distributed .info files into a single root .info file",
 	Long: `Collects all .info files from subdirectories and consolidates them into
@@ -30,8 +30,8 @@ This command:
 - Deletes the subdirectory .info files after successful collection
 
 Example:
-  treex infos-collect              # Collect in current directory
-  treex infos-collect ~/project    # Collect in specific directory`,
+  treex info-collect              # Collect in current directory
+  treex info-collect ~/project    # Collect in specific directory`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runInfosCollect,
 }

--- a/cmd/treex/commands/init.go
+++ b/cmd/treex/commands/init.go
@@ -17,7 +17,7 @@ var (
 )
 
 var initCmd = &cobra.Command{
-	Use:     "init [path...]",
+	Use:     "info-init [path...]",
 	Short:   "Initialize a .info file for a directory or specific paths",
 	GroupID: "info",
 	Long:    initHelp,

--- a/cmd/treex/commands/init.help.txt
+++ b/cmd/treex/commands/init.help.txt
@@ -13,8 +13,8 @@ This command supports two modes:
    - Each path will be listed in the .info file for documentation
 
 Examples:
-  treex init                           # Initialize .info file for current directory
-  treex init ./src                     # Initialize .info file for src directory  
-  treex init --depth=2                 # Initialize with depth limit of 2
-  treex init --force                   # Overwrite existing .info file without prompting
-  treex init docs/dev/HELP src/main.go bin  # Initialize with specific paths only
+  treex info-init                           # Initialize .info file for current directory
+  treex info-init ./src                     # Initialize .info file for src directory  
+  treex info-init --depth=2                 # Initialize with depth limit of 2
+  treex info-init --force                   # Overwrite existing .info file without prompting
+  treex info-init docs/dev/HELP src/main.go bin  # Initialize with specific paths only

--- a/cmd/treex/commands/root.go
+++ b/cmd/treex/commands/root.go
@@ -11,9 +11,9 @@ var (
 	noIgnore   bool
 	infoFile   string
 	maxDepth   int
-	ignoreWarnings bool
+	infoIgnoreWarnings bool
 	// Format is defined in show.go since it's shared
-	// modeFlag is also defined in show.go since it's shared between root and show commands
+	// infoModeFlag is also defined in show.go since it's shared between root and show commands
 )
 
 //go:embed formats.help.txt
@@ -116,7 +116,7 @@ func init() {
 		"color, no-color, markdown (see formats command)")
 
 	// View mode flag
-	rootCmd.Flags().StringVar(&modeFlag, "mode", "mix",
+	rootCmd.Flags().StringVar(&infoModeFlag, "info-mode", "mix",
 		"View mode: mix, annotated, all")
 
 	// Overlay plugins flag
@@ -128,7 +128,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&noIgnore, "no-ignore", false, "Don't use any ignore file")
 	rootCmd.Flags().StringVar(&infoFile, "info-file", ".info", "Use specified info file name instead of .info")
 	rootCmd.Flags().IntVarP(&maxDepth, "depth", "d", 10, "Maximum depth to traverse")
-	rootCmd.Flags().BoolVar(&ignoreWarnings, "ignore-warnings", false, "Don't print warnings for non-existent paths in .info files")
+	rootCmd.Flags().BoolVar(&infoIgnoreWarnings, "info-ignore-warnings", false, "Don't print warnings for non-existent paths in .info files")
 
 	// Add formats command to the root
 	rootCmd.AddCommand(formatsCmd)

--- a/cmd/treex/commands/search.go
+++ b/cmd/treex/commands/search.go
@@ -12,7 +12,7 @@ import (
 )
 
 var searchCmd = &cobra.Command{
-	Use:   "search <term>",
+	Use:   "info-search <term>",
 	Short: "Search for a term in all .info files",
 	Long:  "Search recursively finds all .info files and searches for the given term in both paths and annotations",
 	Args:  cobra.ExactArgs(1),

--- a/cmd/treex/commands/search_test.go
+++ b/cmd/treex/commands/search_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// setupSearchCmd creates a properly initialized test search command
+// setupSearchCmd creates a properly initialized test info-search command
 func setupSearchCmd() *cobra.Command {
 	// Reset infoFile to default
 	infoFile = ".info"
@@ -24,19 +24,19 @@ func setupSearchCmd() *cobra.Command {
 		},
 	}
 
-	// Add the search command
+	// Add the info-search command
 	testRootCmd.AddCommand(searchCmd)
 
 	return testRootCmd
 }
 
-// executeSearchCommand is a helper function to execute the search command
+// executeSearchCommand is a helper function to execute the info-search command
 func executeSearchCommand(args ...string) (output string, err error) {
 	root := setupSearchCmd()
 	buf := new(bytes.Buffer)
 	root.SetOut(buf)
 	root.SetErr(buf)
-	root.SetArgs(append([]string{"search"}, args...))
+	root.SetArgs(append([]string{"info-search"}, args...))
 
 	_, err = root.ExecuteC()
 	return buf.String(), err

--- a/cmd/treex/commands/show.go
+++ b/cmd/treex/commands/show.go
@@ -22,7 +22,7 @@ var (
 	// Format-based flags (new system)
 	outputFormat string
 	// View mode flag
-	modeFlag string
+	infoModeFlag string
 	// Overlay plugins flag
 	overlayPlugins []string
 )
@@ -51,7 +51,7 @@ func init() {
 		"Output format: color, no-color, markdown (use --help for details)")
 
 	// View mode flag
-	showCmd.Flags().StringVar(&modeFlag, "mode", "mix",
+	showCmd.Flags().StringVar(&infoModeFlag, "info-mode", "mix",
 		"View mode: mix, annotated, all (use --help for details)")
 
 	// Overlay plugins flag
@@ -63,7 +63,7 @@ func init() {
 	showCmd.Flags().BoolVar(&noIgnore, "no-ignore", false, "Don't use any ignore file")
 	showCmd.Flags().StringVar(&infoFile, "info-file", ".info", "Use specified info file name instead of .info")
 	showCmd.Flags().IntVarP(&maxDepth, "depth", "d", 10, "Maximum depth to traverse")
-	showCmd.Flags().BoolVar(&ignoreWarnings, "ignore-warnings", false, "Don't print warnings for non-existent paths in .info files")
+	showCmd.Flags().BoolVar(&infoIgnoreWarnings, "info-ignore-warnings", false, "Don't print warnings for non-existent paths in .info files")
 
 	// Register the command with root
 	rootCmd.AddCommand(showCmd)
@@ -103,17 +103,17 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Validate view mode
-	if modeFlag != "" {
+	if infoModeFlag != "" {
 		validModes := []string{"mix", "annotated", "all"}
 		isValid := false
 		for _, mode := range validModes {
-			if modeFlag == mode {
+			if infoModeFlag == mode {
 				isValid = true
 				break
 			}
 		}
 		if !isValid {
-			return fmt.Errorf("invalid view mode: %s (must be 'mix', 'annotated', or 'all')", modeFlag)
+			return fmt.Errorf("invalid view mode: %s (must be 'mix', 'annotated', or 'all')", infoModeFlag)
 		}
 	}
 
@@ -150,7 +150,7 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 		options := app.RenderOptions{
 			Verbose:      verbose,
 			Format:       outputFormat, // New format system
-			ViewMode:     modeFlag,
+			ViewMode:     infoModeFlag,
 			IgnoreFile:   resolvedIgnoreFile,
 			InfoFileName: infoFile,
 			MaxDepth:     maxDepth,
@@ -165,7 +165,7 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		// Check if this is a first-time user scenario (no annotations found)
-		if result.Stats != nil && result.Stats.AnnotationsFound == 0 && modeFlag != "annotated" {
+		if result.Stats != nil && result.Stats.AnnotationsFound == 0 && infoModeFlag != "annotated" {
 			// Generate first-use message using the template
 			firstUseMessage, err := generateFirstUseMessageForPath(targetPath, options)
 			if err == nil && firstUseMessage != "" {
@@ -186,7 +186,7 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		// Display warnings if any
-		if len(result.Warnings) > 0 && !ignoreWarnings {
+		if len(result.Warnings) > 0 && !infoIgnoreWarnings {
 			printWarnings(cmd, result.Warnings)
 		}
 	}

--- a/cmd/treex/commands/show.help.txt
+++ b/cmd/treex/commands/show.help.txt
@@ -21,9 +21,9 @@ treex supports multiple output formats:
 VIEW MODES:
 
 Control which paths are displayed:
-  --mode=mix        Show annotations with contextual paths (default)
-  --mode=annotated  Show only annotated paths
-  --mode=all        Show all paths (equivalent to standard tree command)
+  --info-mode=mix        Show annotations with contextual paths (default)
+  --info-mode=annotated  Show only annotated paths
+  --info-mode=all        Show all paths (equivalent to standard tree command)
 
 OTHER OPTIONS:
   --depth=N          Maximum depth to traverse (default: 10)
@@ -39,7 +39,7 @@ Examples:
   treex                           # Show current directory with annotations
   treex /path/to/project          # Show specific directory
   treex --format=no-color > tree.txt    # Export as plain text
-  treex --mode=annotated          # Show only files with annotations
+  treex --info-mode=annotated          # Show only files with annotations
   treex --overlay=size,date-created  # Show file sizes and creation dates
   treex --overlay=lc                 # Show line counts for text files
   treex src tests --depth=3       # Show src and tests, max depth 3

--- a/cmd/treex/commands/show_integration_test.go
+++ b/cmd/treex/commands/show_integration_test.go
@@ -203,7 +203,7 @@ func TestShowCmd_Integration_ViewModes(t *testing.T) {
 			testShowCmd := setupShowCmd()
 			testRootCmd.AddCommand(testShowCmd)
 
-			output, err := executeCommand(testRootCmd, "show", tempDir, "--format=no-color", "--mode="+tc.viewMode)
+			output, err := executeCommand(testRootCmd, "show", tempDir, "--format=no-color", "--info-mode="+tc.viewMode)
 			if err != nil {
 				t.Fatalf("Show command failed: %v", err)
 			}

--- a/cmd/treex/commands/show_test.go
+++ b/cmd/treex/commands/show_test.go
@@ -33,12 +33,12 @@ func executeCommandC(root *cobra.Command, args ...string) (c *cobra.Command, out
 func resetGlobalFlags() {
 	verbose = false
 	outputFormat = "color"
-	modeFlag = "mix"
+	infoModeFlag = "mix"
 	ignoreFile = ".gitignore"
 	noIgnore = false
 	infoFile = ".info"
 	maxDepth = 10
-	ignoreWarnings = false
+	infoIgnoreWarnings = false
 	overlayPlugins = []string{}
 }
 
@@ -58,12 +58,12 @@ func setupShowCmd() *cobra.Command {
 	// Add the same flags as the original show command
 	testShowCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show verbose output")
 	testShowCmd.Flags().StringVar(&outputFormat, "format", "color", "Output format")
-	testShowCmd.Flags().StringVar(&modeFlag, "mode", "mix", "View mode: mix, annotated, all")
+	testShowCmd.Flags().StringVar(&infoModeFlag, "info-mode", "mix", "View mode: mix, annotated, all")
 	testShowCmd.Flags().StringSliceVar(&overlayPlugins, "overlay", []string{}, "Show additional file information")
 	testShowCmd.Flags().StringVar(&ignoreFile, "use-ignore-file", ".gitignore", "Use specified ignore file")
 	testShowCmd.Flags().BoolVar(&noIgnore, "no-ignore", false, "Don't use any ignore file")
 	testShowCmd.Flags().StringVar(&infoFile, "info-file", ".info", "Use specified info file name instead of .info")
-	testShowCmd.Flags().BoolVar(&ignoreWarnings, "ignore-warnings", false, "Don't print warnings for non-existent paths in .info files")
+	testShowCmd.Flags().BoolVar(&infoIgnoreWarnings, "info-ignore-warnings", false, "Don't print warnings for non-existent paths in .info files")
 	testShowCmd.Flags().IntVarP(&maxDepth, "depth", "d", 10, "Maximum depth to traverse")
 
 	return testShowCmd

--- a/cmd/treex/commands/show_warnings_test.go
+++ b/cmd/treex/commands/show_warnings_test.go
@@ -70,7 +70,7 @@ real.txt This is a real file`
 
 	// Test with --ignore-warnings flag
 	cmd := newTestShowCommand()
-	cmd.SetArgs([]string{"--ignore-warnings"})
+	cmd.SetArgs([]string{"--info-ignore-warnings"})
 	output, err := executeTestCommand(cmd)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -78,10 +78,10 @@ real.txt This is a real file`
 
 	// Check that warnings are NOT present
 	if strings.Contains(output, "⚠️  Warnings found in .info files:") {
-		t.Error("warnings should not be shown with --ignore-warnings")
+		t.Error("warnings should not be shown with --info-ignore-warnings")
 	}
 	if strings.Contains(output, "Path not found") {
-		t.Error("path warnings should not be shown with --ignore-warnings")
+		t.Error("path warnings should not be shown with --info-ignore-warnings")
 	}
 
 	// But the tree should still be shown
@@ -128,13 +128,13 @@ sub Second file`
 // Helper function to create a new show command for testing
 func newTestShowCommand() *cobra.Command {
 	// Reset global variables to default values
-	ignoreWarnings = false
+	infoIgnoreWarnings = false
 	infoFile = ".info"
 	ignoreFile = ".gitignore"
 	noIgnore = false
 	maxDepth = 10
 	outputFormat = "no-color"
-	modeFlag = "mix"
+	infoModeFlag = "mix"
 	verbose = false
 	overlayPlugins = []string{}
 	
@@ -148,13 +148,13 @@ func newTestShowCommand() *cobra.Command {
 	}
 
 	// Add all the flags that runShowCmd expects
-	root.Flags().BoolVar(&ignoreWarnings, "ignore-warnings", false, "Don't print warnings")
+	root.Flags().BoolVar(&infoIgnoreWarnings, "info-ignore-warnings", false, "Don't print warnings")
 	root.Flags().StringVar(&infoFile, "info-file", ".info", "Info file name")
 	root.Flags().StringVar(&ignoreFile, "ignore-file", ".gitignore", "Ignore file")
 	root.Flags().BoolVar(&noIgnore, "no-ignore", false, "Don't use ignore file")
 	root.Flags().IntVarP(&maxDepth, "depth", "d", 10, "Max depth")
 	root.Flags().StringVarP(&outputFormat, "format", "f", "no-color", "Output format")
-	root.Flags().StringVar(&modeFlag, "mode", "mix", "Show mode")
+	root.Flags().StringVar(&infoModeFlag, "info-mode", "mix", "Show mode")
 	root.Flags().StringSliceVar(&overlayPlugins, "overlay", []string{}, "Show plugins")
 	root.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 

--- a/cmd/treex/commands/sync.go
+++ b/cmd/treex/commands/sync.go
@@ -17,7 +17,7 @@ var (
 )
 
 var syncCmd = &cobra.Command{
-	Use:   "sync",
+	Use:   "info-sync",
 	Short: "Remove annotations for non-existent paths from .info files",
 	Long:  "Sync scans all .info files and removes annotations for paths that no longer exist",
 	RunE:  runSync,

--- a/cmd/treex/commands/sync_test.go
+++ b/cmd/treex/commands/sync_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// setupSyncCmd creates a properly initialized test sync command
+// setupSyncCmd creates a properly initialized test info-sync command
 func setupSyncCmd() *cobra.Command {
 	// Reset flags
 	forceSync = false
@@ -25,19 +25,19 @@ func setupSyncCmd() *cobra.Command {
 		},
 	}
 
-	// Add the sync command
+	// Add the info-sync command
 	testRootCmd.AddCommand(syncCmd)
 
 	return testRootCmd
 }
 
-// executeSyncCommand is a helper function to execute the sync command
+// executeSyncCommand is a helper function to execute the info-sync command
 func executeSyncCommand(args ...string) (output string, err error) {
 	root := setupSyncCmd()
 	buf := new(bytes.Buffer)
 	root.SetOut(buf)
 	root.SetErr(buf)
-	root.SetArgs(append([]string{"sync"}, args...))
+	root.SetArgs(append([]string{"info-sync"}, args...))
 
 	_, err = root.ExecuteC()
 	return buf.String(), err


### PR DESCRIPTION
## Summary

This experimental PR reorganizes the treex CLI to clearly separate info/annotation functionality from general tree visualization features. This sets the foundation for expanding treex beyond info file visualization into a general-purpose file tree tool.

## Changes

### Commands Renamed
All info file-related commands now have the `info-` prefix:
- `add` → `info-add`
- `import` → `info-import`
- `init` → `info-init`
- `edit` → `info-edit`
- `del` → `info-del`
- `draw` → `info-draw`
- `infos-collect` → `info-collect`
- `search` → `info-search`
- `sync` → `info-sync`
- `info-files` → `info-help`

### Flags Renamed
Info-specific flags also get the prefix:
- `--mode` → `--info-mode`
- `--ignore-warnings` → `--info-ignore-warnings`

## Rationale

treex began as a way to visualize info files / spatial file system annotations. While this is valuable, treex has potential as a general-purpose file tree tool. This reorganization creates a clear separation between:

1. **Info/annotation features**: All commands and flags with `info-` prefix
2. **General tree features**: Core visualization, formatting, and future non-info capabilities

## Examples

Before:
```bash
treex add main.go "Entry point"
treex edit
treex search test
treex --mode annotated
```

After:
```bash
treex info-add main.go "Entry point"
treex info-edit
treex info-search test
treex --info-mode annotated
```

## Impact

- **Backward compatibility**: This is a breaking change for CLI users
- **Clarity**: Clear distinction between info-specific and general features
- **Future expansion**: Opens the door for non-info tree features

## Test plan

- [x] All existing tests updated and passing
- [x] Interactive testing of all renamed commands
- [x] Help text and documentation updated

This is an experimental branch to explore ideas and try new things freely.

🤖 Generated with [Claude Code](https://claude.ai/code)