### PR TITLE
feat: enhance search match output with highlighted terms

### DIFF
--- a/cmd/treex/commands/root.go
+++ b/cmd/treex/commands/root.go
@@ -131,6 +131,7 @@ func init() {
 	rootCmd.Flags().StringVar(&infoFile, "info-file", ".info", "Use specified info file name instead of .info")
 	rootCmd.Flags().IntVarP(&maxDepth, "depth", "d", 10, "Maximum depth to traverse")
 	rootCmd.Flags().BoolVar(&infoIgnoreWarnings, "info-ignore-warnings", false, "Don't print warnings for non-existent paths in .info files")
+	rootCmd.Flags().BoolVar(&showMatches, "show-matches", true, "Show matching lines when using text queries")
 
 	// Initialize query system for root command (same as show)
 	if queryCLI == nil {

--- a/cmd/treex/commands/show.go
+++ b/cmd/treex/commands/show.go
@@ -191,8 +191,8 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to display tree for %s: %w", targetPath, err)
 		}
 
-		// Check if this is a first-time user scenario (no annotations found)
-		if result.Stats != nil && result.Stats.AnnotationsFound == 0 && infoModeFlag != "annotated" {
+		// Check if this is a first-time user scenario (no annotations found and no query)
+		if result.Stats != nil && result.Stats.AnnotationsFound == 0 && infoModeFlag != "annotated" && userQuery == nil {
 			// Generate first-use message using the template
 			firstUseMessage, err := generateFirstUseMessageForPath(targetPath, options)
 			if err == nil && firstUseMessage != "" {

--- a/cmd/treex/commands/show.go
+++ b/cmd/treex/commands/show.go
@@ -28,6 +28,8 @@ var (
 	overlayPlugins []string
 	// Query system integration
 	queryCLI *query.CLIIntegration
+	// Show matches flag
+	showMatches bool
 )
 
 //go:embed show.help.txt
@@ -67,6 +69,7 @@ func init() {
 	showCmd.Flags().StringVar(&infoFile, "info-file", ".info", "Use specified info file name instead of .info")
 	showCmd.Flags().IntVarP(&maxDepth, "depth", "d", 10, "Maximum depth to traverse")
 	showCmd.Flags().BoolVar(&infoIgnoreWarnings, "info-ignore-warnings", false, "Don't print warnings for non-existent paths in .info files")
+	showCmd.Flags().BoolVar(&showMatches, "show-matches", true, "Show matching lines when using text queries")
 
 	// Initialize query system
 	if err := query.InitializeQuerySystem(); err != nil {
@@ -183,6 +186,7 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 			Config:       cfg,
 			OverlayPlugins: overlayPlugins,
 			Query:         userQuery,
+			ShowMatches:  showMatches,
 		}
 
 		// Call the main business logic

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -31,6 +31,8 @@ type RenderOptions struct {
 	OverlayPlugins []string
 	// Query for filtering files and directories
 	Query interface{} // Will be *query.Query, but using interface{} to avoid circular dependency
+	// ShowMatches indicates whether to show matching lines for text queries
+	ShowMatches bool
 }
 
 // RenderResult contains the rendered output and optional verbose information
@@ -145,11 +147,19 @@ func RenderAnnotatedTree(targetPath string, options RenderOptions) (*RenderResul
 			// Count total files for estimation
 			totalFiles := query.CountTotalFiles(root)
 			
-			// Create a matcher with the query
-			matcher := query.NewMatcher(query.GetGlobalRegistry(), q)
-			
 			// Filter the tree with limits
-			filteredRoot, err := query.FilterTreeWithLimits(root, matcher, limiter)
+			var filteredRoot *types.Node
+			var err error
+			
+			if options.ShowMatches {
+				// Use match collector for text queries
+				collector := query.NewMatchCollector(query.GetGlobalRegistry(), q, true)
+				filteredRoot, err = query.FilterTreeWithMatches(root, collector, limiter)
+			} else {
+				// Use regular matcher
+				matcher := query.NewMatcher(query.GetGlobalRegistry(), q)
+				filteredRoot, err = query.FilterTreeWithLimits(root, matcher, limiter)
+			}
 			if err != nil {
 				return nil, fmt.Errorf("failed to apply query filter: %w", err)
 			}

--- a/pkg/core/query/filter_with_matches.go
+++ b/pkg/core/query/filter_with_matches.go
@@ -1,0 +1,88 @@
+package query
+
+import (
+	"github.com/adebert/treex/pkg/core/limits"
+	"github.com/adebert/treex/pkg/core/types"
+)
+
+// FilterTreeWithMatches filters a tree and collects matching lines
+func FilterTreeWithMatches(node *types.Node, collector *MatchCollector, limiter *limits.Limiter) (*types.Node, error) {
+	// Check if we've exceeded the runtime limit
+	if !limiter.CheckTimeout() {
+		return nil, nil
+	}
+	
+	// First, check if this node matches and get matches
+	matches, matchLines, err := collector.MatchesWithDetail(node)
+	if err != nil {
+		return nil, err
+	}
+	
+	// Record that we processed this file
+	if !node.IsDir {
+		limiter.RecordFileProcessed()
+	}
+	
+	// For directories, we need to check children first
+	if node.IsDir && len(node.Children) > 0 {
+		var filteredChildren []*types.Node
+		childMatches := false
+		
+		for _, child := range node.Children {
+			// Check timeout before processing each child
+			if !limiter.CheckTimeout() {
+				break
+			}
+			
+			filteredChild, err := FilterTreeWithMatches(child, collector, limiter)
+			if err != nil {
+				return nil, err
+			}
+			if filteredChild != nil {
+				filteredChildren = append(filteredChildren, filteredChild)
+				childMatches = true
+			}
+		}
+		
+		// A directory is included if:
+		// 1. It matches the query itself, OR
+		// 2. It has at least one matching child
+		if matches || childMatches {
+			// Create a copy of the node with filtered children
+			filteredNode := &types.Node{
+				Name:         node.Name,
+				Path:         node.Path,
+				RelativePath: node.RelativePath,
+				IsDir:        node.IsDir,
+				Annotation:   node.Annotation,
+				Metadata:     node.Metadata,
+				Children:     filteredChildren,
+				Parent:       node.Parent,
+				Matches:      matchLines,
+			}
+			return filteredNode, nil
+		}
+		
+		// Directory doesn't match and has no matching children
+		return nil, nil
+	}
+	
+	// For files, simply return the node if it matches
+	if matches {
+		// Create a copy to avoid modifying the original
+		filteredNode := &types.Node{
+			Name:         node.Name,
+			Path:         node.Path,
+			RelativePath: node.RelativePath,
+			IsDir:        node.IsDir,
+			Annotation:   node.Annotation,
+			Metadata:     node.Metadata,
+			Children:     nil,
+			Parent:       node.Parent,
+			Matches:      matchLines,
+		}
+		return filteredNode, nil
+	}
+	
+	return nil, nil
+}

--- a/pkg/core/query/match_collector.go
+++ b/pkg/core/query/match_collector.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"regexp"
 	"strings"
-	
+
 	"github.com/adebert/treex/pkg/core/types"
 )
 
@@ -29,10 +29,10 @@ func (mc *MatchCollector) MatchesWithDetail(node *types.Node) (bool, []types.Mat
 	if err != nil || !matches || !mc.collectMatches {
 		return matches, nil, err
 	}
-	
+
 	// If it matches and we're collecting matches, find the specific lines
 	var allMatches []types.Match
-	
+
 	// Check each filter for text-based matches
 	for _, filter := range mc.query.Filters {
 		if filter.Attribute == "text" {
@@ -41,74 +41,113 @@ func (mc *MatchCollector) MatchesWithDetail(node *types.Node) (bool, []types.Mat
 			if !exists {
 				continue
 			}
-			
+
 			// Read file content again (not ideal, but keeps separation of concerns)
 			content, err := readFileContent(node.Path)
 			if err != nil {
 				continue
 			}
-			
+
 			// Collect matches based on operator type
 			switch filter.Operator {
 			case "contains", "not-contains":
 				searchStr := strings.ToLower(filter.Value.(string))
 				lines := strings.Split(content, "\n")
 				for i, line := range lines {
-					if strings.Contains(strings.ToLower(line), searchStr) {
+					lowerLine := strings.ToLower(line)
+					if strings.Contains(lowerLine, searchStr) {
 						if filter.Operator == "contains" {
+							// Trim the line first to get the actual content we'll display
+							trimmedLine := strings.TrimSpace(line)
+							// Find positions in the trimmed line
+							positions := findAllPositions(trimmedLine, filter.Value.(string))
 							allMatches = append(allMatches, types.Match{
-								LineNumber: i + 1,
-								Line:       strings.TrimSpace(line),
+								LineNumber:     i + 1,
+								Line:           trimmedLine,
+								MatchPositions: positions,
 							})
 						}
 					}
 				}
-				
+
 			case "matches", "not-matches":
 				pattern := filter.Value.(string)
 				re, err := regexp.Compile("(?i)" + pattern)
 				if err != nil {
 					continue
 				}
-				
+
 				scanner := bufio.NewScanner(strings.NewReader(content))
 				lineNum := 1
 				for scanner.Scan() {
 					line := scanner.Text()
-					if re.MatchString(line) {
-						if filter.Operator == "matches" {
-							allMatches = append(allMatches, types.Match{
-								LineNumber: lineNum,
-								Line:       strings.TrimSpace(line),
-							})
+					trimmedLine := strings.TrimSpace(line)
+					matches := re.FindAllStringIndex(trimmedLine, -1)
+					if len(matches) > 0 && filter.Operator == "matches" {
+						// Convert matches to our position format
+						positions := make([][]int, len(matches))
+						for i, match := range matches {
+							positions[i] = []int{match[0], match[1]}
 						}
+						allMatches = append(allMatches, types.Match{
+							LineNumber:     lineNum,
+							Line:           trimmedLine,
+							MatchPositions: positions,
+						})
 					}
 					lineNum++
 				}
-				
+
 			case "starts-with", "ends-with":
 				searchStr := strings.ToLower(filter.Value.(string))
+				originalSearchStr := filter.Value.(string)
 				lines := strings.Split(content, "\n")
 				for i, line := range lines {
-					lowerLine := strings.ToLower(strings.TrimSpace(line))
-					matched := false
-					
+					trimmedLine := strings.TrimSpace(line)
+					lowerLine := strings.ToLower(trimmedLine)
+					var positions [][]int
+
 					if filter.Operator == "starts-with" && strings.HasPrefix(lowerLine, searchStr) {
-						matched = true
+						// Match is at the beginning
+						positions = [][]int{{0, len(originalSearchStr)}}
 					} else if filter.Operator == "ends-with" && strings.HasSuffix(lowerLine, searchStr) {
-						matched = true
+						// Match is at the end
+						start := len(trimmedLine) - len(originalSearchStr)
+						positions = [][]int{{start, len(trimmedLine)}}
 					}
-					
-					if matched {
+
+					if len(positions) > 0 {
 						allMatches = append(allMatches, types.Match{
-							LineNumber: i + 1,
-							Line:       strings.TrimSpace(line),
+							LineNumber:     i + 1,
+							Line:           trimmedLine,
+							MatchPositions: positions,
 						})
 					}
 				}
 			}
 		}
 	}
-	
+
 	return matches, allMatches, nil
+}
+
+// findAllPositions finds all case-insensitive positions of searchStr in text
+func findAllPositions(text, searchStr string) [][]int {
+	var positions [][]int
+	lowerText := strings.ToLower(text)
+	lowerSearch := strings.ToLower(searchStr)
+
+	start := 0
+	for {
+		index := strings.Index(lowerText[start:], lowerSearch)
+		if index == -1 {
+			break
+		}
+
+		realIndex := start + index
+		positions = append(positions, []int{realIndex, realIndex + len(searchStr)})
+		start = realIndex + 1
+	}
+
+	return positions
 }

--- a/pkg/core/query/match_collector.go
+++ b/pkg/core/query/match_collector.go
@@ -1,0 +1,114 @@
+package query
+
+import (
+	"bufio"
+	"regexp"
+	"strings"
+	
+	"github.com/adebert/treex/pkg/core/types"
+)
+
+// MatchCollector extends Matcher to also collect matching lines
+type MatchCollector struct {
+	*Matcher
+	collectMatches bool
+}
+
+// NewMatchCollector creates a new match collector
+func NewMatchCollector(registry *Registry, query *Query, collectMatches bool) *MatchCollector {
+	return &MatchCollector{
+		Matcher:        NewMatcher(registry, query),
+		collectMatches: collectMatches,
+	}
+}
+
+// MatchesWithDetail returns whether node matches and collects matching lines for text queries
+func (mc *MatchCollector) MatchesWithDetail(node *types.Node) (bool, []types.Match, error) {
+	// First check if it matches at all
+	matches, err := mc.Matches(node)
+	if err != nil || !matches || !mc.collectMatches {
+		return matches, nil, err
+	}
+	
+	// If it matches and we're collecting matches, find the specific lines
+	var allMatches []types.Match
+	
+	// Check each filter for text-based matches
+	for _, filter := range mc.query.Filters {
+		if filter.Attribute == "text" {
+			// Check if operator exists
+			_, exists := mc.registry.GetOperator(filter.Operator)
+			if !exists {
+				continue
+			}
+			
+			// Read file content again (not ideal, but keeps separation of concerns)
+			content, err := readFileContent(node.Path)
+			if err != nil {
+				continue
+			}
+			
+			// Collect matches based on operator type
+			switch filter.Operator {
+			case "contains", "not-contains":
+				searchStr := strings.ToLower(filter.Value.(string))
+				lines := strings.Split(content, "\n")
+				for i, line := range lines {
+					if strings.Contains(strings.ToLower(line), searchStr) {
+						if filter.Operator == "contains" {
+							allMatches = append(allMatches, types.Match{
+								LineNumber: i + 1,
+								Line:       strings.TrimSpace(line),
+							})
+						}
+					}
+				}
+				
+			case "matches", "not-matches":
+				pattern := filter.Value.(string)
+				re, err := regexp.Compile("(?i)" + pattern)
+				if err != nil {
+					continue
+				}
+				
+				scanner := bufio.NewScanner(strings.NewReader(content))
+				lineNum := 1
+				for scanner.Scan() {
+					line := scanner.Text()
+					if re.MatchString(line) {
+						if filter.Operator == "matches" {
+							allMatches = append(allMatches, types.Match{
+								LineNumber: lineNum,
+								Line:       strings.TrimSpace(line),
+							})
+						}
+					}
+					lineNum++
+				}
+				
+			case "starts-with", "ends-with":
+				searchStr := strings.ToLower(filter.Value.(string))
+				lines := strings.Split(content, "\n")
+				for i, line := range lines {
+					lowerLine := strings.ToLower(strings.TrimSpace(line))
+					matched := false
+					
+					if filter.Operator == "starts-with" && strings.HasPrefix(lowerLine, searchStr) {
+						matched = true
+					} else if filter.Operator == "ends-with" && strings.HasSuffix(lowerLine, searchStr) {
+						matched = true
+					}
+					
+					if matched {
+						allMatches = append(allMatches, types.Match{
+							LineNumber: i + 1,
+							Line:       strings.TrimSpace(line),
+						})
+					}
+				}
+			}
+		}
+	}
+	
+	return matches, allMatches, nil
+}

--- a/pkg/core/types/types.go
+++ b/pkg/core/types/types.go
@@ -28,7 +28,9 @@ type Node struct {
 type Match struct {
 	LineNumber int
 	Line       string
-	// Could add more fields like column ranges for highlighting
+	// MatchPositions contains start and end positions of matching terms
+	// Each pair represents [start, end) indices for a match
+	MatchPositions [][]int
 }
 
 // SortChildren sorts the children of a node alphabetically by name.

--- a/pkg/core/types/types.go
+++ b/pkg/core/types/types.go
@@ -21,6 +21,14 @@ type Node struct {
 	Metadata     map[string]interface{} // Plugin-generated metadata
 	Children     []*Node                // Child nodes (for directories)
 	Parent       *Node                  // Parent node (nil for root)
+	Matches      []Match                // Query matches for this node
+}
+
+// Match represents a matched line in a file
+type Match struct {
+	LineNumber int
+	Line       string
+	// Could add more fields like column ranges for highlighting
 }
 
 // SortChildren sorts the children of a node alphabetically by name.

--- a/pkg/display/rendering/styled_renderer.go
+++ b/pkg/display/rendering/styled_renderer.go
@@ -391,21 +391,23 @@ func (r *StyledTreeRenderer) renderNode(node *types.Node, prefix, continuationPr
 	// Render matches if present
 	if len(node.Matches) > 0 {
 		for _, match := range node.Matches {
-			// Format: "   42: <line content>"
-			// Use continuation prefix to align with tree structure
-			matchLine := fmt.Sprintf("%s%s%d: %s", 
-				continuationPrefix, 
+			// Format the prefix with line number
+			prefix := fmt.Sprintf("%s%s%d: ",
+				continuationPrefix,
 				"   ", // Extra indent for matches
-				match.LineNumber,
-				match.Line)
-			
-			// Style the match line in a subdued color
-			styledMatch := r.styles.UnannotatedPath.Render(matchLine)
-			if _, err := fmt.Fprintf(r.writer, "%s\n", styledMatch); err != nil {
+				match.LineNumber)
+
+			// Apply subdued style to the prefix
+			styledPrefix := r.styles.UnannotatedPath.Render(prefix)
+
+			// Style the line content with highlighted matches
+			styledLine := r.styleMatchLine(match.Line, match.MatchPositions)
+
+			if _, err := fmt.Fprintf(r.writer, "%s%s\n", styledPrefix, styledLine); err != nil {
 				return err
 			}
 		}
-		
+
 		// Add spacing after matches if needed
 		if shouldAddSpacing {
 			if _, err := fmt.Fprintln(r.writer); err != nil {
@@ -415,6 +417,51 @@ func (r *StyledTreeRenderer) renderNode(node *types.Node, prefix, continuationPr
 	}
 
 	return nil
+}
+
+// styleMatchLine applies styles to a line with match positions highlighted
+func (r *StyledTreeRenderer) styleMatchLine(line string, positions [][]int) string {
+	if len(positions) == 0 {
+		// No matches, return the line with subdued style
+		return r.styles.Base.TextSubtle.Render(line)
+	}
+
+	// Sort positions by start index to ensure correct ordering
+	sortedPositions := make([][]int, len(positions))
+	copy(sortedPositions, positions)
+	// Simple bubble sort since we typically have few positions
+	for i := 0; i < len(sortedPositions)-1; i++ {
+		for j := 0; j < len(sortedPositions)-i-1; j++ {
+			if sortedPositions[j][0] > sortedPositions[j+1][0] {
+				sortedPositions[j], sortedPositions[j+1] = sortedPositions[j+1], sortedPositions[j]
+			}
+		}
+	}
+
+	var result string
+	lastEnd := 0
+
+	for _, pos := range sortedPositions {
+		// Ensure positions are within bounds
+		if pos[0] < 0 || pos[1] > len(line) || pos[0] >= pos[1] {
+			continue
+		}
+
+		if pos[0] > lastEnd {
+			// Add subdued text before the match
+			result += r.styles.Base.TextSubtle.Render(line[lastEnd:pos[0]])
+		}
+		// Add highlighted match
+		result += r.styles.TermMatching.Render(line[pos[0]:pos[1]])
+		lastEnd = pos[1]
+	}
+
+	// Add any remaining subdued text after the last match
+	if lastEnd < len(line) {
+		result += r.styles.Base.TextSubtle.Render(line[lastEnd:])
+	}
+
+	return result
 }
 
 // formatInlineAnnotation formats the primary annotation text for inline display
@@ -473,14 +520,14 @@ func (r *StyledTreeRenderer) formatPluginMetadata(node *types.Node) string {
 	if r.pluginRegistry == nil || len(r.enabledPlugins) == 0 || len(node.Metadata) == 0 {
 		return ""
 	}
-	
+
 	// Format metadata from each enabled plugin
 	formattedMetadata := r.pluginRegistry.FormatMetadata(node, r.enabledPlugins)
-	
+
 	if len(formattedMetadata) == 0 {
 		return ""
 	}
-	
+
 	// Combine multiple plugin outputs with appropriate styling
 	var styledMetadata []string
 	for _, metadata := range formattedMetadata {
@@ -490,11 +537,11 @@ func (r *StyledTreeRenderer) formatPluginMetadata(node *types.Node) string {
 			styledMetadata = append(styledMetadata, styled)
 		}
 	}
-	
+
 	if len(styledMetadata) == 0 {
 		return ""
 	}
-	
+
 	// Join multiple plugin outputs with spacing
 	return "[" + strings.Join(styledMetadata, " | ") + "]"
 }
@@ -619,7 +666,6 @@ func RenderStyledTreeWithConfig(writer io.Writer, root *types.Node, showAnnotati
 	renderer := NewStyledTreeRendererWithConfig(writer, showAnnotations, cfg)
 	return renderer.Render(root)
 }
-
 
 // RenderStyledTreeToStringWithConfig renders a tree to a string using configuration-based styling
 func RenderStyledTreeToStringWithConfig(root *types.Node, showAnnotations bool, cfg *config.Config) (string, error) {

--- a/pkg/display/rendering/styled_renderer.go
+++ b/pkg/display/rendering/styled_renderer.go
@@ -388,6 +388,32 @@ func (r *StyledTreeRenderer) renderNode(node *types.Node, prefix, continuationPr
 		return err
 	}
 
+	// Render matches if present
+	if len(node.Matches) > 0 {
+		for _, match := range node.Matches {
+			// Format: "   42: <line content>"
+			// Use continuation prefix to align with tree structure
+			matchLine := fmt.Sprintf("%s%s%d: %s", 
+				continuationPrefix, 
+				"   ", // Extra indent for matches
+				match.LineNumber,
+				match.Line)
+			
+			// Style the match line in a subdued color
+			styledMatch := r.styles.UnannotatedPath.Render(matchLine)
+			if _, err := fmt.Fprintf(r.writer, "%s\n", styledMatch); err != nil {
+				return err
+			}
+		}
+		
+		// Add spacing after matches if needed
+		if shouldAddSpacing {
+			if _, err := fmt.Fprintln(r.writer); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/display/styles/styles.go
+++ b/pkg/display/styles/styles.go
@@ -46,6 +46,9 @@ type TreeStyles struct {
 	// Layout styles
 	AnnotationSeparator lipgloss.Style
 	MultiLineIndent     lipgloss.Style
+
+	// Search match styles
+	TermMatching lipgloss.Style // For highlighting matching terms in search results
 }
 
 // NewBaseStyles creates base style components
@@ -104,6 +107,9 @@ func NewTreeStyles() *TreeStyles {
 		MultiLineIndent: base.Border.
 			Faint(true).
 			PaddingLeft(1),
+
+		// Search match styles
+		TermMatching: base.Warning.Italic(true), // Yellow and italic for matching terms
 	}
 }
 
@@ -148,6 +154,9 @@ func NewMinimalTreeStyles() *TreeStyles {
 		// Layout styles
 		AnnotationSeparator: base.Text.SetString("  "),
 		MultiLineIndent:     base.Text.PaddingLeft(1),
+
+		// Search match styles
+		TermMatching: base.Text.Italic(true), // Italic only for minimal color scheme
 	}
 }
 
@@ -191,5 +200,8 @@ func NewNoColorTreeStyles() *TreeStyles {
 		// Layout styles
 		AnnotationSeparator: base.Text.SetString("  "),
 		MultiLineIndent:     base.Text,
+
+		// Search match styles
+		TermMatching: base.Text.Italic(true), // Italic only for no-color scheme
 	}
 }


### PR DESCRIPTION
## Summary
- Adds yellow italic highlighting for matching terms in search results
- Makes non-matching parts of result lines more subdued for better visual contrast  
- Tracks precise match positions within lines for all search operators

## Test plan
- [x] Run `go test ./...` - all tests pass
- [x] Test search functionality with various operators:
  ```bash
  treex show --text--contains example --show-matches
  treex show --text--matches "test.*pattern" --show-matches
  treex show --text--starts-with func --show-matches
  treex show --text--ends-with "}" --show-matches
  ```
- [x] Verify highlighting appears correctly in terminal output
- [x] Test with multiple matches on a single line
- [x] Verify no regressions in tree display without search

🤖 Generated with [Claude Code](https://claude.ai/code)